### PR TITLE
Visual polish: gradients, glass cards, history grouping

### DIFF
--- a/Baseline.xcodeproj/project.pbxproj
+++ b/Baseline.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		0BAB7EB581FEBEC95104DC1E /* TrendsViewSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FFC7E5904AEB1F7A6957D2D /* TrendsViewSnapshotTests.swift */; };
 		0C50ABA464D39A2FE1AAC9FC /* MetricHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5998E990E3771B0504227A72 /* MetricHistoryView.swift */; };
 		0D82FB85309F585B25DFA19B /* ArcIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08676595D1E00491EDB74DF5 /* ArcIndicatorView.swift */; };
+		6CFEB0E0629C6205349D2964 /* GradientBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F75D29D530A43D2588D84A /* GradientBackground.swift */; };
+		D45EE0A20FB785973D9206A0 /* GlassCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15D80B91DBB8B57CC3D79170 /* GlassCard.swift */; };
 		AA22BB33CC44DD55EE66FF88 /* GoalReachedOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB33CC44DD55EE66FF77AA88 /* GoalReachedOverlay.swift */; };
 		1420080C176B26B2E12FEE83 /* HistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A472F5E582548C05BBD1A751 /* HistoryView.swift */; };
 		14FE980511237871E2644BEE /* BaselineApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 007A5A45919FF650EAB251AE /* BaselineApp.swift */; };
@@ -149,6 +151,8 @@
 		0070AF17E85C200AF4B68F44 /* WeightLockScreenWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeightLockScreenWidget.swift; sourceTree = "<group>"; };
 		007A5A45919FF650EAB251AE /* BaselineApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaselineApp.swift; sourceTree = "<group>"; };
 		08676595D1E00491EDB74DF5 /* ArcIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArcIndicatorView.swift; sourceTree = "<group>"; };
+		C9F75D29D530A43D2588D84A /* GradientBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradientBackground.swift; sourceTree = "<group>"; };
+		15D80B91DBB8B57CC3D79170 /* GlassCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassCard.swift; sourceTree = "<group>"; };
 		BB33CC44DD55EE66FF77AA88 /* GoalReachedOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalReachedOverlay.swift; sourceTree = "<group>"; };
 		16180890AC21C5FBC902279E /* BodyViewSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BodyViewSnapshotTests.swift; sourceTree = "<group>"; };
 		18F90EA3B79CAA8467685396 /* HealthKitManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthKitManagerTests.swift; sourceTree = "<group>"; };
@@ -467,6 +471,8 @@
 			isa = PBXGroup;
 			children = (
 				08676595D1E00491EDB74DF5 /* ArcIndicatorView.swift */,
+				C9F75D29D530A43D2588D84A /* GradientBackground.swift */,
+				15D80B91DBB8B57CC3D79170 /* GlassCard.swift */,
 				BB33CC44DD55EE66FF77AA88 /* GoalReachedOverlay.swift */,
 				F48EFFC280B6AF1B4D90AADE /* MetricTile.swift */,
 				A1F7BB657D83894D1E5B4400 /* SparklineView.swift */,
@@ -817,6 +823,8 @@
 				E0288A71F6279F2726D154B0 /* APIClient.swift in Sources */,
 				4468566A53F28207A9455BBB /* AppState.swift in Sources */,
 				0D82FB85309F585B25DFA19B /* ArcIndicatorView.swift in Sources */,
+				6CFEB0E0629C6205349D2964 /* GradientBackground.swift in Sources */,
+				D45EE0A20FB785973D9206A0 /* GlassCard.swift in Sources */,
 				AA22BB33CC44DD55EE66FF88 /* GoalReachedOverlay.swift in Sources */,
 				14FE980511237871E2644BEE /* BaselineApp.swift in Sources */,
 				785C5DEE4B6E4E89A3FB7D25 /* BaselineTips.swift in Sources */,

--- a/Baseline/Design/CadreTokens.swift
+++ b/Baseline/Design/CadreTokens.swift
@@ -15,8 +15,17 @@ enum CadreColors {
     static let textSecondary = Color(hex: "797B83")
     static let textTertiary = Color(hex: "494B52")
 
+    // Glass card — translucent version of card for use over gradients
+    static let cardGlass = Color(hex: "17171B").opacity(0.75)
+    static let cardBorder = Color.white.opacity(0.06)
+
     // Divider
     static let divider = Color(hex: "2A2A30")
+
+    // Background gradient — subtle cool depth
+    // Radial glow: a whisper of dusty blue bleeding into the charcoal
+    static let bgGradientCenter = Color(hex: "111520")  // barely-blue charcoal
+    static let bgGradientEdge = Color(hex: "0B0B0E")    // == bg, pure charcoal
 
     // Accent — dusty blue (swappable token; amber + warm-gray in reserve)
     static let accent = Color(hex: "6B7B94")

--- a/Baseline/Design/Components/GlassCard.swift
+++ b/Baseline/Design/Components/GlassCard.swift
@@ -11,6 +11,7 @@ struct GlassCard: ViewModifier {
             .background(
                 RoundedRectangle(cornerRadius: cornerRadius)
                     .fill(CadreColors.cardGlass)
+                    .shadow(color: .black.opacity(0.35), radius: 8, x: 0, y: 4)
             )
             .overlay(
                 RoundedRectangle(cornerRadius: cornerRadius)

--- a/Baseline/Design/Components/GlassCard.swift
+++ b/Baseline/Design/Components/GlassCard.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+/// Applies a translucent "glass" card treatment: semi-transparent fill
+/// with a thin bright border. Use on views that sit over `GradientBackground`
+/// so the gradient bleeds through subtly.
+struct GlassCard: ViewModifier {
+    var cornerRadius: CGFloat = CadreRadius.md
+
+    func body(content: Content) -> some View {
+        content
+            .background(
+                RoundedRectangle(cornerRadius: cornerRadius)
+                    .fill(CadreColors.cardGlass)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: cornerRadius)
+                    .strokeBorder(CadreColors.cardBorder, lineWidth: 1)
+            )
+    }
+}
+
+extension View {
+    func glassCard(cornerRadius: CGFloat = CadreRadius.md) -> some View {
+        modifier(GlassCard(cornerRadius: cornerRadius))
+    }
+}

--- a/Baseline/Design/Components/GradientBackground.swift
+++ b/Baseline/Design/Components/GradientBackground.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+/// Subtle radial gradient background that replaces flat `CadreColors.bg`.
+///
+/// Adds depth with a barely-visible dusty-blue glow radiating from a
+/// configurable anchor point. The effect is intentionally understated —
+/// perceptible as "not flat" without reading as an obvious gradient.
+struct GradientBackground: View {
+    var center: UnitPoint = .top
+
+    var body: some View {
+        RadialGradient(
+            colors: [
+                CadreColors.bgGradientCenter,
+                CadreColors.bgGradientEdge
+            ],
+            center: center,
+            startRadius: 0,
+            endRadius: 600
+        )
+        .ignoresSafeArea()
+    }
+}

--- a/Baseline/Design/Components/MetricTile.swift
+++ b/Baseline/Design/Components/MetricTile.swift
@@ -67,8 +67,8 @@ struct MetricTile: View {
         .padding(.horizontal, 12)
         .padding(.vertical, 13)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(CadreColors.card)
         .clipShape(RoundedRectangle(cornerRadius: CadreRadius.md))
+        .glassCard()
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(tileAccessibilityLabel)
     }
@@ -130,8 +130,8 @@ struct MetricTileEmpty: View {
         .padding(.horizontal, 12)
         .padding(.vertical, 13)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(CadreColors.card)
         .clipShape(RoundedRectangle(cornerRadius: CadreRadius.md))
+        .glassCard()
     }
 }
 

--- a/Baseline/Models/WeightEntry.swift
+++ b/Baseline/Models/WeightEntry.swift
@@ -16,7 +16,7 @@ class WeightEntry {
         self.id = UUID()
         self.weight = weight
         self.unit = unit
-        self.date = Calendar.current.startOfDay(for: date)
+        self.date = date
         self.notes = notes
         self.photoData = photoData
         self.createdAt = Date()

--- a/Baseline/ViewModels/HistoryViewModel.swift
+++ b/Baseline/ViewModels/HistoryViewModel.swift
@@ -54,9 +54,10 @@ class HistoryViewModel {
 
     /// Check if a weight entry exists for the given date (excluding a specific entry).
     func existingEntry(for date: Date, excluding entryID: UUID) -> WeightEntry? {
-        let targetDay = Calendar.current.startOfDay(for: date)
+        let dayStart = Calendar.current.startOfDay(for: date)
+        let dayEnd = Calendar.current.date(byAdding: .day, value: 1, to: dayStart)!
         let descriptor = FetchDescriptor<WeightEntry>(
-            predicate: #Predicate { $0.date == targetDay }
+            predicate: #Predicate { $0.date >= dayStart && $0.date < dayEnd }
         )
         return (try? modelContext.fetch(descriptor))?.first(where: { $0.id != entryID })
     }
@@ -71,7 +72,13 @@ class HistoryViewModel {
         entry.weight = weight
         entry.notes = trimmed.isEmpty ? nil : trimmed
         if let date {
-            entry.date = Calendar.current.startOfDay(for: date)
+            // Preserve time of day: use noon on the selected date so it sorts correctly
+            var components = Calendar.current.dateComponents([.year, .month, .day], from: date)
+            let originalTime = Calendar.current.dateComponents([.hour, .minute, .second], from: entry.date)
+            components.hour = originalTime.hour
+            components.minute = originalTime.minute
+            components.second = originalTime.second
+            entry.date = Calendar.current.date(from: components) ?? date
         }
         entry.updatedAt = Date()
         do {

--- a/Baseline/ViewModels/NowViewModel.swift
+++ b/Baseline/ViewModels/NowViewModel.swift
@@ -38,11 +38,12 @@ class NowViewModel {
     }
 
     func refresh() {
-        let today = Calendar.current.startOfDay(for: Date())
+        let todayStart = Calendar.current.startOfDay(for: Date())
+        let tomorrowStart = Calendar.current.date(byAdding: .day, value: 1, to: todayStart)!
 
-        // Fetch today's entry
+        // Fetch today's entry (any time today)
         var todayDescriptor = FetchDescriptor<WeightEntry>(
-            predicate: #Predicate { $0.date == today }
+            predicate: #Predicate { $0.date >= todayStart && $0.date < tomorrowStart }
         )
         todayDescriptor.fetchLimit = 1
         do {
@@ -53,7 +54,7 @@ class NowViewModel {
 
         // Fetch most recent entry before today
         var previousDescriptor = FetchDescriptor<WeightEntry>(
-            predicate: #Predicate { $0.date < today },
+            predicate: #Predicate { $0.date < todayStart },
             sortBy: [SortDescriptor(\.date, order: .reverse)]
         )
         previousDescriptor.fetchLimit = 1

--- a/Baseline/ViewModels/WeighInViewModel.swift
+++ b/Baseline/ViewModels/WeighInViewModel.swift
@@ -16,11 +16,12 @@ class WeighInViewModel {
         self.currentWeight = lastWeight ?? (unit == "kg" ? 70.0 : 150.0)
     }
 
-    /// Check if a weigh-in already exists for the given date.
+    /// Check if a weigh-in already exists for the given date (any time that day).
     func existingEntry(for date: Date) -> WeightEntry? {
-        let targetDay = Calendar.current.startOfDay(for: date)
+        let dayStart = Calendar.current.startOfDay(for: date)
+        let dayEnd = Calendar.current.date(byAdding: .day, value: 1, to: dayStart)!
         var descriptor = FetchDescriptor<WeightEntry>(
-            predicate: #Predicate { $0.date == targetDay }
+            predicate: #Predicate { $0.date >= dayStart && $0.date < dayEnd }
         )
         descriptor.fetchLimit = 1
         return try? modelContext.fetch(descriptor).first
@@ -35,12 +36,13 @@ class WeighInViewModel {
     }
 
     func save(date: Date = Date(), photoData: Data? = nil) {
-        let targetDay = Calendar.current.startOfDay(for: date)
+        let dayStart = Calendar.current.startOfDay(for: date)
+        let dayEnd = Calendar.current.date(byAdding: .day, value: 1, to: dayStart)!
         let trimmedNotes = notes.trimmingCharacters(in: .whitespacesAndNewlines)
         let notesToSave: String? = trimmedNotes.isEmpty ? nil : trimmedNotes
 
         var descriptor = FetchDescriptor<WeightEntry>(
-            predicate: #Predicate { $0.date == targetDay }
+            predicate: #Predicate { $0.date >= dayStart && $0.date < dayEnd }
         )
         descriptor.fetchLimit = 1
 

--- a/Baseline/Views/Body/BodyView.swift
+++ b/Baseline/Views/Body/BodyView.swift
@@ -39,7 +39,7 @@ struct BodyView: View {
     var body: some View {
         NavigationStack {
             ZStack {
-                CadreColors.bg.ignoresSafeArea()
+                GradientBackground(center: .top)
 
                 ScrollView {
                     VStack(spacing: 0) {
@@ -202,8 +202,8 @@ struct BodyView: View {
             }
             .padding(.horizontal, 14)
             .padding(.vertical, 14)
-            .background(CadreColors.card)
             .clipShape(RoundedRectangle(cornerRadius: CadreRadius.md))
+            .glassCard()
         }
         .buttonStyle(.plain)
     }

--- a/Baseline/Views/Body/BodyView.swift
+++ b/Baseline/Views/Body/BodyView.swift
@@ -32,8 +32,8 @@ struct BodyView: View {
     // MARK: - Grid
 
     private let tileColumns = [
-        GridItem(.flexible(), spacing: 8),
-        GridItem(.flexible(), spacing: 8)
+        GridItem(.flexible(), spacing: 10),
+        GridItem(.flexible(), spacing: 10)
     ]
 
     var body: some View {
@@ -49,10 +49,11 @@ struct BodyView: View {
                         bodyCompositionSection
                         scanHistoryCard
                             .padding(.horizontal, CadreSpacing.sheetHorizontal)
-                            .padding(.top, 12)
+                            .padding(.top, 16)
                         measurementsSection
+                            .padding(.top, 8)
                     }
-                    .padding(.bottom, 24)
+                    .padding(.bottom, 32)
                 }
             }
             .toolbar {
@@ -93,7 +94,7 @@ struct BodyView: View {
             )
 
             if let tiles = bodyCompTiles, !tiles.isEmpty {
-                LazyVGrid(columns: tileColumns, spacing: 8) {
+                LazyVGrid(columns: tileColumns, spacing: 10) {
                     ForEach(tiles, id: \.label) { tile in
                         if let trendName = trendMetricName(for: tile.label) {
                             Button {
@@ -152,7 +153,7 @@ struct BodyView: View {
 
             let tiles = measurementTiles
             if !tiles.isEmpty {
-                LazyVGrid(columns: tileColumns, spacing: 8) {
+                LazyVGrid(columns: tileColumns, spacing: 10) {
                     ForEach(tiles, id: \.label) { tile in
                         MeasurementTileLink(
                             tile: tile,

--- a/Baseline/Views/Body/LogMeasurementSheet.swift
+++ b/Baseline/Views/Body/LogMeasurementSheet.swift
@@ -28,7 +28,7 @@ struct LogMeasurementSheet: View {
 
     var body: some View {
         ZStack {
-            CadreColors.bg.ignoresSafeArea()
+            GradientBackground(center: .top)
 
             VStack(spacing: 0) {
                 sheetHandle
@@ -277,7 +277,7 @@ struct LogMeasurementSheet: View {
     private var typePickerSheet: some View {
         NavigationStack {
             ZStack {
-                CadreColors.bg.ignoresSafeArea()
+                GradientBackground(center: .top)
                 List {
                     ForEach(MeasurementType.allCases, id: \.self) { type in
                         Button {

--- a/Baseline/Views/Body/MetricHistoryView.swift
+++ b/Baseline/Views/Body/MetricHistoryView.swift
@@ -12,6 +12,26 @@ struct MetricHistoryView: View {
     let unit: String
     let entries: [(date: Date, value: String)]
 
+    private func groupedEntries() -> [(key: String, entries: [(date: Date, value: String)])] {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMMM yyyy"
+        var groups: [(key: String, entries: [(date: Date, value: String)])] = []
+        var currentKey = ""
+        var currentGroup: [(date: Date, value: String)] = []
+        for entry in entries {
+            let key = formatter.string(from: entry.date)
+            if key != currentKey {
+                if !currentGroup.isEmpty { groups.append((key: currentKey, entries: currentGroup)) }
+                currentKey = key
+                currentGroup = [entry]
+            } else {
+                currentGroup.append(entry)
+            }
+        }
+        if !currentGroup.isEmpty { groups.append((key: currentKey, entries: currentGroup)) }
+        return groups
+    }
+
     var body: some View {
         ZStack {
             GradientBackground(center: .top)
@@ -27,39 +47,52 @@ struct MetricHistoryView: View {
                 }
             } else {
                 List {
-                    ForEach(Array(entries.enumerated()), id: \.offset) { _, entry in
-                        HStack(spacing: 16) {
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text("\(Calendar.current.component(.day, from: entry.date))")
-                                    .font(.system(size: 28, weight: .bold))
-                                    .foregroundStyle(CadreColors.textPrimary)
-                                Text({
-                                    let f = DateFormatter(); f.dateFormat = "MMM yyyy"
-                                    return f.string(from: entry.date)
-                                }())
-                                    .font(.system(size: 12, weight: .medium))
-                                    .foregroundStyle(CadreColors.textSecondary)
-                            }
-                            .frame(width: 60, alignment: .leading)
+                    ForEach(groupedEntries(), id: \.key) { group in
+                        Section {
+                            ForEach(Array(group.entries.enumerated()), id: \.offset) { _, entry in
+                                HStack(spacing: 0) {
+                                    VStack(alignment: .leading, spacing: 3) {
+                                        Text({
+                                            let f = DateFormatter(); f.dateFormat = "EEEE"
+                                            return f.string(from: entry.date)
+                                        }())
+                                            .font(.system(size: 14, weight: .semibold))
+                                            .foregroundStyle(CadreColors.textPrimary)
+                                        Text({
+                                            let f = DateFormatter(); f.dateFormat = "MMM d"
+                                            return f.string(from: entry.date)
+                                        }())
+                                            .font(.system(size: 12, weight: .medium))
+                                            .foregroundStyle(CadreColors.textTertiary)
+                                    }
 
-                            Spacer()
+                                    Spacer()
 
-                            HStack(alignment: .firstTextBaseline, spacing: 3) {
-                                Text(entry.value)
-                                    .font(.system(size: 22, weight: .bold))
-                                    .foregroundStyle(CadreColors.textPrimary)
-                                if !unit.isEmpty {
-                                    Text(unit)
-                                        .font(.system(size: 13, weight: .medium))
-                                        .foregroundStyle(CadreColors.textSecondary)
+                                    HStack(alignment: .firstTextBaseline, spacing: 4) {
+                                        Text(entry.value)
+                                            .font(.system(size: 24, weight: .bold))
+                                            .foregroundStyle(CadreColors.textPrimary)
+                                        if !unit.isEmpty {
+                                            Text(unit.uppercased())
+                                                .font(.system(size: 11, weight: .semibold))
+                                                .foregroundStyle(CadreColors.textTertiary)
+                                        }
+                                    }
                                 }
+                                .listRowBackground(CadreColors.cardGlass)
+                                .listRowSeparatorTint(CadreColors.divider.opacity(0.5))
+                                .listRowInsets(EdgeInsets(top: 16, leading: 16, bottom: 16, trailing: 16))
                             }
+                        } header: {
+                            Text(group.key.uppercased())
+                                .font(.system(size: 11, weight: .semibold))
+                                .tracking(0.5)
+                                .foregroundStyle(CadreColors.textTertiary)
+                                .listRowInsets(EdgeInsets(top: 16, leading: 4, bottom: 8, trailing: 0))
                         }
-                        .listRowBackground(CadreColors.card)
-                        .listRowInsets(EdgeInsets(top: 12, leading: CadreSpacing.md, bottom: 12, trailing: CadreSpacing.md))
                     }
                 }
-                .listStyle(.plain)
+                .listStyle(.insetGrouped)
                 .scrollContentBackground(.hidden)
             }
         }
@@ -99,33 +132,43 @@ struct MeasurementHistoryView: View {
                 }
             } else {
                 List {
-                    ForEach(measurements) { measurement in
-                        MeasurementRow(
-                            measurement: measurement,
-                            delta: delta(for: measurement)
-                        )
-                        .listRowBackground(CadreColors.bg)
-                        .listRowSeparatorTint(CadreColors.divider)
-                        .listRowInsets(EdgeInsets(top: 12, leading: CadreSpacing.md, bottom: 12, trailing: CadreSpacing.md))
-                        .contentShape(Rectangle())
-                        .onTapGesture { editingMeasurement = measurement }
-                        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                            Button(role: .destructive) {
-                                vm?.deleteMeasurement(measurement)
-                                refresh()
-                            } label: {
-                                Label("Delete", systemImage: "trash")
+                    ForEach(groupedMeasurements(), id: \.key) { group in
+                        Section {
+                            ForEach(group.entries) { measurement in
+                                MeasurementRow(
+                                    measurement: measurement,
+                                    delta: delta(for: measurement)
+                                )
+                                .listRowBackground(CadreColors.cardGlass)
+                                .listRowSeparatorTint(CadreColors.divider.opacity(0.5))
+                                .listRowInsets(EdgeInsets(top: 16, leading: 16, bottom: 16, trailing: 16))
+                                .contentShape(Rectangle())
+                                .onTapGesture { editingMeasurement = measurement }
+                                .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                                    Button(role: .destructive) {
+                                        vm?.deleteMeasurement(measurement)
+                                        refresh()
+                                    } label: {
+                                        Label("Delete", systemImage: "trash")
+                                    }
+                                    Button {
+                                        editingMeasurement = measurement
+                                    } label: {
+                                        Label("Edit", systemImage: "pencil")
+                                    }
+                                    .tint(CadreColors.accent)
+                                }
                             }
-                            Button {
-                                editingMeasurement = measurement
-                            } label: {
-                                Label("Edit", systemImage: "pencil")
-                            }
-                            .tint(CadreColors.accent)
+                        } header: {
+                            Text(group.key.uppercased())
+                                .font(.system(size: 11, weight: .semibold))
+                                .tracking(0.5)
+                                .foregroundStyle(CadreColors.textTertiary)
+                                .listRowInsets(EdgeInsets(top: 16, leading: 4, bottom: 8, trailing: 0))
                         }
                     }
                 }
-                .listStyle(.plain)
+                .listStyle(.insetGrouped)
                 .scrollContentBackground(.hidden)
             }
         }
@@ -189,6 +232,26 @@ struct MeasurementHistoryView: View {
         measurements = vm?.allMeasurements(ofType: metricType) ?? []
     }
 
+    private func groupedMeasurements() -> [(key: String, entries: [BodyMeasurement])] {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMMM yyyy"
+        var groups: [(key: String, entries: [BodyMeasurement])] = []
+        var currentKey = ""
+        var currentGroup: [BodyMeasurement] = []
+        for m in measurements {
+            let key = formatter.string(from: m.date)
+            if key != currentKey {
+                if !currentGroup.isEmpty { groups.append((key: currentKey, entries: currentGroup)) }
+                currentKey = key
+                currentGroup = [m]
+            } else {
+                currentGroup.append(m)
+            }
+        }
+        if !currentGroup.isEmpty { groups.append((key: currentKey, entries: currentGroup)) }
+        return groups
+    }
+
     /// Delta from the chronologically-previous entry, in display units.
     private func delta(for measurement: BodyMeasurement) -> Double? {
         guard let idx = measurements.firstIndex(where: { $0.id == measurement.id }) else { return nil }
@@ -214,45 +277,44 @@ private struct MeasurementRow: View {
         UnitConversion.displayLength(measurement.valueCm).value
     }
 
-    private var dayNumber: String {
-        "\(Calendar.current.component(.day, from: measurement.date))"
+    private var dateLabel: String {
+        let f = DateFormatter(); f.dateFormat = "MMM d"
+        return f.string(from: measurement.date)
     }
 
-    private var monthYear: String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "MMM yyyy"
-        return formatter.string(from: measurement.date)
+    private var weekdayLabel: String {
+        let f = DateFormatter(); f.dateFormat = "EEEE"
+        return f.string(from: measurement.date)
     }
 
     var body: some View {
         VStack(spacing: 0) {
-            HStack(spacing: 16) {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(dayNumber)
-                        .font(.system(size: 28, weight: .bold))
+            HStack(spacing: 0) {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(weekdayLabel)
+                        .font(.system(size: 14, weight: .semibold))
                         .foregroundStyle(CadreColors.textPrimary)
-                    Text(monthYear)
+                    Text(dateLabel)
                         .font(.system(size: 12, weight: .medium))
-                        .foregroundStyle(CadreColors.textSecondary)
+                        .foregroundStyle(CadreColors.textTertiary)
                 }
-                .frame(width: 60, alignment: .leading)
 
                 Spacer()
 
-                VStack(alignment: .trailing, spacing: 4) {
-                    HStack(alignment: .firstTextBaseline, spacing: 3) {
-                        Text(String(format: "%.1f", displayValue))
-                            .font(.system(size: 22, weight: .bold))
-                            .foregroundStyle(CadreColors.textPrimary)
-                        Text(displayUnit)
-                            .font(.system(size: 13, weight: .medium))
-                            .foregroundStyle(CadreColors.textSecondary)
-                    }
-                    if let delta {
-                        Text(formatDelta(delta))
-                            .font(.system(size: 13, weight: .medium))
-                            .foregroundStyle(deltaColor(delta))
-                    }
+                HStack(alignment: .firstTextBaseline, spacing: 4) {
+                    Text(String(format: "%.1f", displayValue))
+                        .font(.system(size: 24, weight: .bold))
+                        .foregroundStyle(CadreColors.textPrimary)
+                    Text(displayUnit.uppercased())
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(CadreColors.textTertiary)
+                }
+
+                if let delta {
+                    Text(formatDelta(delta))
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(deltaColor(delta))
+                        .padding(.leading, 10)
                 }
             }
 

--- a/Baseline/Views/Body/MetricHistoryView.swift
+++ b/Baseline/Views/Body/MetricHistoryView.swift
@@ -14,7 +14,7 @@ struct MetricHistoryView: View {
 
     var body: some View {
         ZStack {
-            CadreColors.bg.ignoresSafeArea()
+            GradientBackground(center: .top)
 
             if entries.isEmpty {
                 VStack(spacing: 12) {
@@ -86,7 +86,7 @@ struct MeasurementHistoryView: View {
 
     var body: some View {
         ZStack {
-            CadreColors.bg.ignoresSafeArea()
+            GradientBackground(center: .top)
 
             if measurements.isEmpty {
                 VStack(spacing: 12) {

--- a/Baseline/Views/Body/ScanDetailView.swift
+++ b/Baseline/Views/Body/ScanDetailView.swift
@@ -22,7 +22,7 @@ struct ScanDetailView: View {
 
     var body: some View {
         ZStack {
-            CadreColors.bg.ignoresSafeArea()
+            GradientBackground(center: .top)
 
             if let content {
                 ScrollView {
@@ -392,7 +392,7 @@ struct ScanEditView: View {
     var body: some View {
         NavigationStack {
             ZStack {
-                CadreColors.bg.ignoresSafeArea()
+                GradientBackground(center: .top)
 
                 VStack(spacing: 0) {
                     ScrollView {

--- a/Baseline/Views/Body/ScanDetailView.swift
+++ b/Baseline/Views/Body/ScanDetailView.swift
@@ -47,7 +47,7 @@ struct ScanDetailView: View {
         }
         .navigationTitle(scanTitle)
         .navigationBarTitleDisplayMode(.inline)
-        .toolbarBackground(CadreColors.bg, for: .navigationBar)
+        .toolbarBackground(CadreColors.bgGradientCenter, for: .navigationBar)
         .toolbarColorScheme(.dark, for: .navigationBar)
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
@@ -435,7 +435,7 @@ struct ScanEditView: View {
                         .foregroundStyle(CadreColors.textSecondary)
                 }
             }
-            .toolbarBackground(CadreColors.bg, for: .navigationBar)
+            .toolbarBackground(CadreColors.bgGradientCenter, for: .navigationBar)
             .toolbarColorScheme(.dark, for: .navigationBar)
         }
     }

--- a/Baseline/Views/Body/ScanEntryFlow.swift
+++ b/Baseline/Views/Body/ScanEntryFlow.swift
@@ -27,7 +27,7 @@ struct ScanEntryFlow: View {
     var body: some View {
         NavigationStack {
             ZStack {
-                CadreColors.bg.ignoresSafeArea()
+                GradientBackground(center: .top)
 
                 if let vm = resolvedVM {
                     // AnyView breaks the type metadata chain — without it, the

--- a/Baseline/Views/Body/ScanHistoryView.swift
+++ b/Baseline/Views/Body/ScanHistoryView.swift
@@ -15,7 +15,7 @@ struct ScanHistoryView: View {
 
     var body: some View {
         ZStack {
-            CadreColors.bg.ignoresSafeArea()
+            GradientBackground(center: .top)
 
             if scans.isEmpty {
                 emptyState

--- a/Baseline/Views/History/HistoryView.swift
+++ b/Baseline/Views/History/HistoryView.swift
@@ -25,7 +25,7 @@ struct HistoryView: View {
 
     var body: some View {
         ZStack {
-            CadreColors.bg.ignoresSafeArea()
+            GradientBackground(center: .top)
 
             if let vm, !vm.entries.isEmpty {
                 list(vm: vm)

--- a/Baseline/Views/History/HistoryView.swift
+++ b/Baseline/Views/History/HistoryView.swift
@@ -35,7 +35,7 @@ struct HistoryView: View {
         }
         .navigationTitle("History")
         .navigationBarTitleDisplayMode(.inline)
-        .toolbarBackground(CadreColors.bg, for: .navigationBar)
+        .toolbarBackground(CadreColors.bgGradientCenter, for: .navigationBar)
         .toolbarColorScheme(.dark, for: .navigationBar)
         .sheet(item: $editingEntry) { entry in
             EditEntrySheet(
@@ -61,36 +61,73 @@ struct HistoryView: View {
         }
     }
 
+    // MARK: - Grouped by month
+
+    /// Groups entries by "Month Year" (e.g. "April 2026"), preserving reverse-chronological order.
+    private func groupedEntries(_ entries: [WeightEntry]) -> [(key: String, entries: [WeightEntry])] {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMMM yyyy"
+        var groups: [(key: String, entries: [WeightEntry])] = []
+        var currentKey = ""
+        var currentGroup: [WeightEntry] = []
+        for entry in entries {
+            let key = formatter.string(from: entry.date)
+            if key != currentKey {
+                if !currentGroup.isEmpty {
+                    groups.append((key: currentKey, entries: currentGroup))
+                }
+                currentKey = key
+                currentGroup = [entry]
+            } else {
+                currentGroup.append(entry)
+            }
+        }
+        if !currentGroup.isEmpty {
+            groups.append((key: currentKey, entries: currentGroup))
+        }
+        return groups
+    }
+
     // MARK: - List
 
     private func list(vm: HistoryViewModel) -> some View {
         List {
-            ForEach(vm.entries) { entry in
-                HistoryRow(
-                    entry: entry,
-                    delta: vm.delta(for: entry)
-                )
-                .listRowBackground(CadreColors.bg)
-                .listRowSeparatorTint(CadreColors.divider)
-                .listRowInsets(EdgeInsets(top: 12, leading: CadreSpacing.md, bottom: 12, trailing: CadreSpacing.md))
-                .contentShape(Rectangle())
-                .onTapGesture { editingEntry = entry }
-                .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                    Button(role: .destructive) {
-                        vm.delete(entry)
-                    } label: {
-                        Label("Delete", systemImage: "trash")
+            ForEach(groupedEntries(vm.entries), id: \.key) { group in
+                Section {
+                    ForEach(group.entries) { entry in
+                        HistoryRow(
+                            entry: entry,
+                            delta: vm.delta(for: entry)
+                        )
+                        .listRowBackground(CadreColors.cardGlass)
+                        .listRowSeparatorTint(CadreColors.divider.opacity(0.5))
+                        .listRowInsets(EdgeInsets(top: 16, leading: 16, bottom: 16, trailing: 16))
+                        .contentShape(Rectangle())
+                        .onTapGesture { editingEntry = entry }
+                        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                            Button(role: .destructive) {
+                                vm.delete(entry)
+                            } label: {
+                                Label("Delete", systemImage: "trash")
+                            }
+                            Button {
+                                editingEntry = entry
+                            } label: {
+                                Label("Edit", systemImage: "pencil")
+                            }
+                            .tint(CadreColors.accent)
+                        }
                     }
-                    Button {
-                        editingEntry = entry
-                    } label: {
-                        Label("Edit", systemImage: "pencil")
-                    }
-                    .tint(CadreColors.accent)
+                } header: {
+                    Text(group.key.uppercased())
+                        .font(.system(size: 11, weight: .semibold))
+                        .tracking(0.5)
+                        .foregroundStyle(CadreColors.textTertiary)
+                        .listRowInsets(EdgeInsets(top: 16, leading: 4, bottom: 8, trailing: 0))
                 }
             }
         }
-        .listStyle(.plain)
+        .listStyle(.insetGrouped)
         .scrollContentBackground(.hidden)
     }
 
@@ -122,14 +159,21 @@ private struct HistoryRow: View {
         return UnitConversion.displayWeight(entry.weight, storedUnit: entry.unit)
     }
 
-    private var dayNumber: String {
-        let cal = Calendar.current
-        return "\(cal.component(.day, from: entry.date))"
+    private var dateLabel: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMM d"
+        return formatter.string(from: entry.date)
     }
 
-    private var monthYear: String {
+    /// Show time only if the entry was logged on the day it represents.
+    /// Back-dated entries have meaningless times (midnight or log time).
+    private var showTime: Bool {
+        Calendar.current.isDate(entry.date, inSameDayAs: entry.createdAt)
+    }
+
+    private var timeLabel: String {
         let formatter = DateFormatter()
-        formatter.dateFormat = "MMM yyyy"
+        formatter.dateFormat = "h:mm a"
         return formatter.string(from: entry.date)
     }
 
@@ -139,37 +183,45 @@ private struct HistoryRow: View {
         return formatter.string(from: entry.date)
     }
 
+    private var weekdayLabel: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "EEEE"
+        return formatter.string(from: entry.date)
+    }
+
     var body: some View {
         VStack(spacing: 0) {
-            HStack(spacing: 16) {
-                // Date block — mirrors ScanHistoryView pattern
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(dayNumber)
-                        .font(.system(size: 28, weight: .bold))
+            HStack(spacing: 0) {
+                // Date + optional time on the left
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(dateLabel)
+                        .font(.system(size: 14, weight: .semibold))
                         .foregroundStyle(CadreColors.textPrimary)
-                    Text(monthYear)
-                        .font(.system(size: 12, weight: .medium))
-                        .foregroundStyle(CadreColors.textSecondary)
+                    if showTime {
+                        Text(timeLabel)
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundStyle(CadreColors.textTertiary)
+                    }
                 }
-                .frame(width: 60, alignment: .leading)
 
                 Spacer()
 
-                // Weight + delta — always in user's preferred unit
-                VStack(alignment: .trailing, spacing: 4) {
-                    HStack(alignment: .firstTextBaseline, spacing: 3) {
-                        Text(UnitConversion.formatWeight(displayWeight, unit: displayUnit))
-                            .font(.system(size: 22, weight: .bold))
-                            .foregroundStyle(CadreColors.textPrimary)
-                        Text(displayUnit)
-                            .font(.system(size: 13, weight: .medium))
-                            .foregroundStyle(CadreColors.textSecondary)
-                    }
-                    if let delta {
-                        Text(UnitConversion.formatDelta(delta))
-                            .font(.system(size: 13, weight: .medium))
-                            .foregroundStyle(deltaColor(delta))
-                    }
+                // Weight — big and bold on the right
+                HStack(alignment: .firstTextBaseline, spacing: 4) {
+                    Text(UnitConversion.formatWeight(displayWeight, unit: displayUnit))
+                        .font(.system(size: 24, weight: .bold))
+                        .foregroundStyle(CadreColors.textPrimary)
+                    Text(displayUnit.uppercased())
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(CadreColors.textTertiary)
+                }
+
+                // Delta badge
+                if let delta {
+                    Text(UnitConversion.formatDelta(delta))
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(deltaColor(delta))
+                        .padding(.leading, 10)
                 }
             }
 
@@ -187,7 +239,7 @@ private struct HistoryRow: View {
     }
 
     private var rowAccessibilityLabel: String {
-        var label = "\(weekday), \(monthYear) \(dayNumber), \(UnitConversion.formatWeight(displayWeight, unit: displayUnit)) \(displayUnit)"
+        var label = "\(weekday), \(dateLabel), \(UnitConversion.formatWeight(displayWeight, unit: displayUnit)) \(displayUnit)"
         if let delta {
             label += ", \(deltaText(delta)) change"
         }
@@ -341,7 +393,7 @@ private struct EditEntrySheet: View {
                 }
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Save") {
-                        let dateChanged = Calendar.current.startOfDay(for: selectedDate) != entry.date
+                        let dateChanged = !Calendar.current.isDate(selectedDate, inSameDayAs: entry.date)
                         if dateChanged && checkConflict(selectedDate, entry.id) {
                             showOverwriteAlert = true
                         } else {

--- a/Baseline/Views/Now/NowView.swift
+++ b/Baseline/Views/Now/NowView.swift
@@ -37,7 +37,7 @@ struct NowView: View {
     var body: some View {
         NavigationStack {
             ZStack {
-                CadreColors.bg.ignoresSafeArea()
+                GradientBackground(center: .top)
 
                 VStack(spacing: 0) {
                     // Hero: arc + number + range toggle, centered in open area
@@ -239,10 +239,7 @@ struct NowView: View {
             }
         }
         .padding(3)
-        .background(
-            RoundedRectangle(cornerRadius: 10)
-                .fill(CadreColors.card)
-        )
+        .glassCard(cornerRadius: 10)
     }
 
     // MARK: - Bottom block (stats + button)
@@ -279,8 +276,8 @@ struct NowView: View {
             statCell(label: "AVERAGE", value: stats.average)
             statCell(label: "HIGHEST", value: stats.highest)
         }
-        .background(CadreColors.divider)
         .clipShape(RoundedRectangle(cornerRadius: 14))
+        .glassCard(cornerRadius: 14)
     }
 
     private var goalStatsCard: some View {
@@ -303,8 +300,8 @@ struct NowView: View {
             goalStatCell(label: "TARGET", value: targetDisplay, unit: unit, accent: true, daysLeft: nil)
             goalStatCell(label: daysLeft.map { "TO GO (\($0)d)" } ?? "TO GO", value: remainingDisplay, unit: unit, accent: false, daysLeft: nil)
         }
-        .background(CadreColors.divider)
         .clipShape(RoundedRectangle(cornerRadius: 14))
+        .glassCard(cornerRadius: 14)
     }
 
     private func goalStatCell(label: String, value: Double?, unit: String, accent: Bool, daysLeft: Int?) -> some View {
@@ -358,7 +355,7 @@ struct NowView: View {
         .frame(maxWidth: .infinity)
         .padding(.vertical, 14)
         .padding(.horizontal, 6)
-        .background(CadreColors.card)
+        .background(CadreColors.cardGlass)
     }
 
     private var weighInButton: some View {

--- a/Baseline/Views/Now/NowView.swift
+++ b/Baseline/Views/Now/NowView.swift
@@ -312,6 +312,8 @@ struct NowView: View {
                 .font(CadreTypography.statLabel)
                 .tracking(0.5)
                 .foregroundStyle(labelColor)
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
             HStack(alignment: .firstTextBaseline, spacing: 2) {
                 Text(value.map { UnitConversion.formatWeight($0, unit: unit) } ?? "—")
                     .font(CadreTypography.statValue)
@@ -327,25 +329,22 @@ struct NowView: View {
         .frame(maxWidth: .infinity)
         .padding(.vertical, 14)
         .padding(.horizontal, 6)
-        .background(CadreColors.card)
+        .background(CadreColors.cardGlass)
     }
 
     private func statCell(label: String, value: Double?) -> some View {
         let unit = vm?.unit ?? "lb"
         return VStack(spacing: 6) {
-            // Uppercase caption — 9pt semibold, 0.5px tracking (mockup .stat .label)
             Text(label)
                 .font(CadreTypography.statLabel)
                 .tracking(0.5)
                 .foregroundStyle(CadreColors.textTertiary)
             HStack(alignment: .firstTextBaseline, spacing: 2) {
-                // Stat value — 18pt bold (mockup .stat .value)
                 Text(value.map { UnitConversion.formatWeight($0, unit: unit) } ?? "—")
                     .font(CadreTypography.statValue)
                     .foregroundStyle(CadreColors.textPrimary)
                     .contentTransition(.numericText())
                 if value != nil {
-                    // Stat unit suffix — 10pt regular (mockup .stat .value .unit)
                     Text(unit)
                         .font(CadreTypography.statUnit)
                         .foregroundStyle(CadreColors.textTertiary)
@@ -371,6 +370,7 @@ struct NowView: View {
                 .padding(.vertical, 18)
                 .background(CadreColors.accent)
                 .clipShape(RoundedRectangle(cornerRadius: 16))
+                .shadow(color: CadreColors.accent.opacity(0.4), radius: 12, x: 0, y: 4)
         }
     }
 

--- a/Baseline/Views/Now/NowView.swift
+++ b/Baseline/Views/Now/NowView.swift
@@ -245,7 +245,7 @@ struct NowView: View {
     // MARK: - Bottom block (stats + button)
 
     private var bottomBlock: some View {
-        VStack(spacing: 18) {
+        VStack(spacing: 20) {
             if goalVM?.activeWeightGoal != nil, showGoalStats {
                 goalStatsCard
                     .onTapGesture {

--- a/Baseline/Views/Now/WeighInSheet.swift
+++ b/Baseline/Views/Now/WeighInSheet.swift
@@ -44,7 +44,7 @@ struct WeighInSheet: View {
     var body: some View {
         NavigationStack {
         ZStack {
-            CadreColors.bg.ignoresSafeArea()
+            GradientBackground(center: .top)
 
             VStack(spacing: 0) {
                 sheetHandle

--- a/Baseline/Views/Settings/SettingsSubscreens.swift
+++ b/Baseline/Views/Settings/SettingsSubscreens.swift
@@ -12,7 +12,7 @@ struct NameEditView: View {
 
     var body: some View {
         ZStack {
-            CadreColors.bg.ignoresSafeArea()
+            GradientBackground(center: .top)
 
             VStack(alignment: .leading, spacing: 0) {
                 // Text input card with accent border
@@ -103,7 +103,7 @@ struct HeightPickerView: View {
 
     var body: some View {
         ZStack {
-            CadreColors.bg.ignoresSafeArea()
+            GradientBackground(center: .top)
 
             VStack(spacing: 0) {
                 if isMetric {
@@ -215,7 +215,7 @@ struct BirthdayPickerView: View {
 
     var body: some View {
         ZStack {
-            CadreColors.bg.ignoresSafeArea()
+            GradientBackground(center: .top)
 
             VStack(spacing: 0) {
                 DatePicker(
@@ -293,7 +293,7 @@ struct GenderPickerView: View {
 
     var body: some View {
         ZStack {
-            CadreColors.bg.ignoresSafeArea()
+            GradientBackground(center: .top)
 
             VStack(spacing: 0) {
                 VStack(spacing: 0) {
@@ -355,7 +355,7 @@ struct ThemePickerView: View {
 
     var body: some View {
         ZStack {
-            CadreColors.bg.ignoresSafeArea()
+            GradientBackground(center: .top)
 
             VStack(spacing: 0) {
                 VStack(spacing: 0) {
@@ -425,7 +425,7 @@ struct CadreSyncView: View {
 
     var body: some View {
         ZStack {
-            CadreColors.bg.ignoresSafeArea()
+            GradientBackground(center: .top)
 
             VStack(alignment: .leading, spacing: 0) {
                 // API URL
@@ -575,7 +575,7 @@ struct ExportCSVView: View {
 
     var body: some View {
         ZStack {
-            CadreColors.bg.ignoresSafeArea()
+            GradientBackground(center: .top)
 
             VStack(spacing: 0) {
                 // Hero icon + title
@@ -680,7 +680,7 @@ private struct ExportItem {
 struct AboutCadreView: View {
     var body: some View {
         ZStack {
-            CadreColors.bg.ignoresSafeArea()
+            GradientBackground(center: .top)
 
             ScrollView {
                 VStack(spacing: 0) {

--- a/Baseline/Views/Settings/SettingsSubscreens.swift
+++ b/Baseline/Views/Settings/SettingsSubscreens.swift
@@ -83,7 +83,7 @@ struct NameEditView: View {
                     .font(.system(size: 15, weight: .semibold))
             }
         }
-        .toolbarBackground(CadreColors.bg, for: .navigationBar)
+        .toolbarBackground(CadreColors.bgGradientCenter, for: .navigationBar)
         .onAppear { draft = viewModel.name }
     }
 }
@@ -190,7 +190,7 @@ struct HeightPickerView: View {
                 .foregroundStyle(CadreColors.accent)
             }
         }
-        .toolbarBackground(CadreColors.bg, for: .navigationBar)
+        .toolbarBackground(CadreColors.bgGradientCenter, for: .navigationBar)
         .onAppear {
             draftFeet = viewModel.heightFeet > 0 ? viewModel.heightFeet : 5
             draftInches = viewModel.heightInches
@@ -276,7 +276,7 @@ struct BirthdayPickerView: View {
                 .foregroundStyle(CadreColors.accent)
             }
         }
-        .toolbarBackground(CadreColors.bg, for: .navigationBar)
+        .toolbarBackground(CadreColors.bgGradientCenter, for: .navigationBar)
         .onAppear {
             if let existing = viewModel.birthday {
                 draftDate = existing
@@ -343,7 +343,7 @@ struct GenderPickerView: View {
                     .tracking(-0.2)
             }
         }
-        .toolbarBackground(CadreColors.bg, for: .navigationBar)
+        .toolbarBackground(CadreColors.bgGradientCenter, for: .navigationBar)
     }
 }
 
@@ -409,7 +409,7 @@ struct ThemePickerView: View {
                     .tracking(-0.2)
             }
         }
-        .toolbarBackground(CadreColors.bg, for: .navigationBar)
+        .toolbarBackground(CadreColors.bgGradientCenter, for: .navigationBar)
     }
 }
 
@@ -533,7 +533,7 @@ struct CadreSyncView: View {
                     .tracking(-0.2)
             }
         }
-        .toolbarBackground(CadreColors.bg, for: .navigationBar)
+        .toolbarBackground(CadreColors.bgGradientCenter, for: .navigationBar)
         .onAppear {
             apiURL = viewModel.syncAPIURL
             apiKey = viewModel.syncAPIKey
@@ -643,7 +643,7 @@ struct ExportCSVView: View {
                     .tracking(-0.2)
             }
         }
-        .toolbarBackground(CadreColors.bg, for: .navigationBar)
+        .toolbarBackground(CadreColors.bgGradientCenter, for: .navigationBar)
     }
 
     private func exportToggle(_ label: String, isOn: Binding<Bool>) -> some View {
@@ -740,7 +740,7 @@ struct AboutCadreView: View {
                     .tracking(-0.2)
             }
         }
-        .toolbarBackground(CadreColors.bg, for: .navigationBar)
+        .toolbarBackground(CadreColors.bgGradientCenter, for: .navigationBar)
     }
 
     private enum BadgeStyle { case current, normal }

--- a/Baseline/Views/Settings/SettingsView.swift
+++ b/Baseline/Views/Settings/SettingsView.swift
@@ -39,7 +39,7 @@ struct SettingsView: View {
             }
         }
         .navigationBarTitleDisplayMode(.inline)
-        .toolbarBackground(CadreColors.bg, for: .navigationBar)
+        .toolbarBackground(CadreColors.bgGradientCenter, for: .navigationBar)
         .toolbar {
             ToolbarItem(placement: .principal) {
                 Text("Settings")
@@ -158,8 +158,8 @@ struct SettingsView: View {
                     )
                 )
             }
-            .padding(.horizontal, 22)
-            .padding(.vertical, 13)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 14)
 
             SettingsDivider()
 
@@ -178,8 +178,8 @@ struct SettingsView: View {
                     )
                 )
             }
-            .padding(.horizontal, 22)
-            .padding(.vertical, 13)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 14)
         }
     }
 
@@ -404,8 +404,8 @@ struct SettingsRow: View {
                     .background(CadreColors.cardElevated, in: RoundedRectangle(cornerRadius: 5))
             }
         }
-        .padding(.horizontal, 22)
-        .padding(.vertical, 13)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
         .contentShape(Rectangle())
     }
 }
@@ -444,7 +444,7 @@ private extension SettingsIconTint {
     }
 }
 
-/// Section container with uppercase label.
+/// Section container with uppercase label and glass card background.
 struct SettingsSectionView<Content: View>: View {
     let title: String
     @ViewBuilder let content: Content
@@ -460,7 +460,12 @@ struct SettingsSectionView<Content: View>: View {
                 .padding(.top, 22)
                 .padding(.bottom, 8)
 
-            content
+            VStack(spacing: 0) {
+                content
+            }
+            .clipShape(RoundedRectangle(cornerRadius: CadreRadius.md))
+            .glassCard()
+            .padding(.horizontal, 16)
         }
     }
 }
@@ -471,7 +476,7 @@ struct SettingsDivider: View {
         Rectangle()
             .fill(CadreColors.divider)
             .frame(height: 0.5)
-            .padding(.leading, 64) // icon width (28) + gap (14) + padding (22)
+            .padding(.leading, 50) // icon width (28) + gap (14) + inner padding (8)
     }
 }
 

--- a/Baseline/Views/Settings/SettingsView.swift
+++ b/Baseline/Views/Settings/SettingsView.swift
@@ -21,7 +21,7 @@ struct SettingsView: View {
 
     var body: some View {
         ZStack {
-            CadreColors.bg.ignoresSafeArea()
+            GradientBackground(center: .top)
 
             ScrollView {
                 VStack(spacing: 0) {

--- a/Baseline/Views/Trends/SetGoalSheet.swift
+++ b/Baseline/Views/Trends/SetGoalSheet.swift
@@ -55,7 +55,7 @@ struct SetGoalSheet: View {
     var body: some View {
         NavigationStack {
             ZStack {
-                CadreColors.bg.ignoresSafeArea()
+                GradientBackground(center: .top)
 
                 ScrollView {
                     VStack(spacing: 16) {

--- a/Baseline/Views/Trends/SetGoalSheet.swift
+++ b/Baseline/Views/Trends/SetGoalSheet.swift
@@ -132,7 +132,7 @@ struct SetGoalSheet: View {
                     .foregroundStyle(CadreColors.textSecondary)
                 }
             }
-            .toolbarBackground(CadreColors.bg, for: .navigationBar)
+            .toolbarBackground(CadreColors.bgGradientCenter, for: .navigationBar)
             .toolbarBackground(.visible, for: .navigationBar)
             .toolbarColorScheme(.dark, for: .navigationBar)
         }

--- a/Baseline/Views/Trends/TrendsView.swift
+++ b/Baseline/Views/Trends/TrendsView.swift
@@ -74,7 +74,7 @@ struct TrendsView: View {
     var body: some View {
         NavigationStack {
             ZStack(alignment: .top) {
-                CadreColors.bg.ignoresSafeArea()
+                GradientBackground(center: .top)
 
                 VStack(spacing: 0) {
                     metricChipButton
@@ -295,14 +295,7 @@ struct TrendsView: View {
             }
             .padding(.horizontal, 14)
             .padding(.vertical, 12)
-            .background(
-                RoundedRectangle(cornerRadius: CadreRadius.md)
-                    .fill(CadreColors.card)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: CadreRadius.md)
-                            .stroke(CadreColors.divider, lineWidth: 1)
-                    )
-            )
+            .glassCard()
         }
         .buttonStyle(.plain)
     }
@@ -333,10 +326,7 @@ struct TrendsView: View {
             }
         }
         .padding(3)
-        .background(
-            RoundedRectangle(cornerRadius: 10)
-                .fill(CadreColors.card)
-        )
+        .glassCard(cornerRadius: 10)
     }
 
     // MARK: - Full variant (2+ data points)
@@ -865,7 +855,7 @@ struct TrendsView: View {
         let hasSecondary = compareEnabled && secondaryMetric != nil && !secondaryPoints.isEmpty
 
         return ZStack {
-            CadreColors.bg.ignoresSafeArea()
+            GradientBackground(center: .top)
 
             HStack(spacing: 0) {
                 // Left panel: metric info

--- a/Baseline/Views/Trends/TrendsView.swift
+++ b/Baseline/Views/Trends/TrendsView.swift
@@ -96,7 +96,7 @@ struct TrendsView: View {
                     Spacer(minLength: 0)
                 }
             }
-            .navigationBarHidden(true)
+            .toolbarVisibility(.hidden, for: .navigationBar)
             .fullScreenCover(isPresented: $showFullscreen) {
                 LandscapeHostingController(content: fullscreenChartContent)
                     .ignoresSafeArea()

--- a/Baseline/Views/Trends/TrendsView.swift
+++ b/Baseline/Views/Trends/TrendsView.swift
@@ -83,7 +83,7 @@ struct TrendsView: View {
 
                     rangeTabs
                         .padding(.horizontal, CadreSpacing.sheetHorizontal)
-                        .padding(.top, 10)
+                        .padding(.top, 12)
 
                     TipView(trendsTip)
                         .padding(.horizontal, CadreSpacing.sheetHorizontal)
@@ -365,12 +365,12 @@ struct TrendsView: View {
 
             chartBlock(points: points, movingAverage: ma)
                 .padding(.horizontal, CadreSpacing.sheetHorizontal)
-                .padding(.top, 14)
+                .padding(.top, 18)
 
             if !ma.isEmpty {
                 legendBlock
                     .padding(.horizontal, CadreSpacing.sheetHorizontal)
-                    .padding(.top, 10)
+                    .padding(.top, 12)
             }
 
             GoalCard(
@@ -381,7 +381,7 @@ struct TrendsView: View {
                 onManageGoal: { showManageGoal = true }
             )
             .padding(.horizontal, CadreSpacing.sheetHorizontal)
-            .padding(.top, 12)
+            .padding(.top, 16)
         }
     }
 


### PR DESCRIPTION
## Summary
- Replace flat black backgrounds with subtle cool-toned radial gradient across all screens
- Add translucent glass card treatment (semi-transparent fill + border + shadow) to metric tiles, stats cards, settings sections, and range toggles
- Group history/measurement rows by month with section headers ("APRIL 2026")
- Preserve weigh-in timestamps and conditionally display time (only when logged same-day)
- Fix nav bar going black on scroll, fix Trends nav bar clipping
- Add accent glow shadow on Weigh In button

## Test plan
- [x] Verify gradient background appears on all tabs and sub-screens
- [x] Verify glass card treatment on Now stats, Body tiles, Trends chip/toggle, Settings sections
- [x] Verify history rows grouped by month with correct headers
- [x] Log a new weigh-in and verify time appears in history
- [x] Log a back-dated entry and verify no time shown
- [x] Scroll on Settings and verify nav bar doesn't go black
- [x] Verify Trends metric chip is not clipped at top

🤖 Generated with [Claude Code](https://claude.com/claude-code)