### PR TITLE
Fix two CRITICAL audit findings (#66, #67)

### DIFF
--- a/Baseline/Models/AppState.swift
+++ b/Baseline/Models/AppState.swift
@@ -10,4 +10,10 @@ import Observation
 class AppState {
     var selectedTab: AppTab = .now
     var trendMetric: String = "Weight"
+
+    /// When true, TrendsView will open the SetGoalSheet on its next
+    /// appear. Used by the goal-reached celebration on NowView so
+    /// tapping "Set New Goal" actually lands the user on the goal
+    /// creation surface instead of silently dismissing.
+    var showSetGoalOnTrendsAppear: Bool = false
 }

--- a/Baseline/Views/Body/ScanEntryFlow.swift
+++ b/Baseline/Views/Body/ScanEntryFlow.swift
@@ -59,6 +59,22 @@ struct ScanEntryFlow: View {
                 vm = ScanEntryViewModel(modelContext: modelContext)
             }
         }
+        // Surface scan-save failures. Without this, `performSave` writes
+        // the error into the VM and nothing displays it — the user taps
+        // Save, nothing happens, and their scan is lost silently.
+        .alert(
+            "Couldn't Save Scan",
+            isPresented: Binding(
+                get: { resolvedVM?.errorMessage != nil },
+                set: { if !$0 { resolvedVM?.errorMessage = nil } }
+            )
+        ) {
+            Button("OK", role: .cancel) {
+                resolvedVM?.errorMessage = nil
+            }
+        } message: {
+            Text(resolvedVM?.errorMessage ?? "Something went wrong while saving. Try again.")
+        }
     }
 
     // MARK: - Step 1: Scan Type Selection

--- a/Baseline/Views/Now/NowView.swift
+++ b/Baseline/Views/Now/NowView.swift
@@ -9,6 +9,7 @@ import TipKit
 /// in open area) → stats card → Weigh In button anchored above tab bar.
 struct NowView: View {
     @Environment(\.modelContext) private var modelContext
+    @Environment(AppState.self) private var appState: AppState?
 
     // Track unit preference so SwiftUI re-renders when it changes
     @AppStorage("weightUnit") private var weightUnit = "lb"
@@ -127,7 +128,12 @@ struct NowView: View {
                         startDate: reachedGoalStartDate,
                         onNewGoal: {
                             showGoalReached = false
-                            // Goal is already completed, user can go to Trends to set a new one
+                            // Route the user to the Trends tab and ask it to
+                            // open the SetGoalSheet on appear. Without the
+                            // AppState hop this button just dismissed the
+                            // overlay and left the user stranded.
+                            appState?.showSetGoalOnTrendsAppear = true
+                            appState?.selectedTab = .trends
                         },
                         onDismiss: {
                             showGoalReached = false

--- a/Baseline/Views/Trends/TrendsView.swift
+++ b/Baseline/Views/Trends/TrendsView.swift
@@ -184,6 +184,17 @@ struct TrendsView: View {
                 }
                 vm?.refresh()
                 availableMetrics = vm?.computeAvailableMetrics() ?? TrendMetric.allCases
+
+                // Honour a pending request from NowView's goal-reached
+                // overlay. Delay by one frame so the tab-switch animation
+                // finishes before the sheet slides up over it.
+                if appState?.showSetGoalOnTrendsAppear == true {
+                    appState?.showSetGoalOnTrendsAppear = false
+                    Task { @MainActor in
+                        try? await Task.sleep(nanoseconds: 250_000_000)
+                        showSetGoal = true
+                    }
+                }
             }
             .onChange(of: appState?.trendMetric) { _, newValue in
                 if let newValue, let metric = TrendMetric(rawValue: newValue) {


### PR DESCRIPTION
Closes #66 and #67. Both were CRITICAL findings from the earlier UX flow audit.

## Summary
- **#66**: \`ScanEntryFlow\` now presents scan-save failures via an \`.alert\` bound to \`vm.errorMessage\`. Previously the VM recorded the error and nothing displayed it — user taps Save, nothing happens, scan lost silently.
- **#67**: The 'Set New Goal' CTA on \`GoalReachedOverlay\` now actually navigates. New \`AppState.showSetGoalOnTrendsAppear\` flag is set when tapped; TrendsView's \`onAppear\` honours it and opens the SetGoalSheet after a 250ms delay so the tab transition lands first.

## Test plan
- [x] 262 tests green (11 skipped are the disabled snapshot tests from #10)
- [ ] Manual: trigger a scan save failure (e.g. force a save error) and verify the alert appears
- [ ] Manual: complete a weight goal, tap 'Set New Goal' on the celebration overlay, confirm landing on Trends with the SetGoalSheet already open

🤖 Generated with [Claude Code](https://claude.com/claude-code)