### PR TITLE
feat(legal): wire up Privacy Policy + ToS for v1.0 (#39)

### DIFF
--- a/Baseline/Info.plist
+++ b/Baseline/Info.plist
@@ -24,8 +24,6 @@
 	<false/>
 	<key>NSCameraUsageDescription</key>
 	<string>Baseline uses the camera to scan InBody printouts and extract your body composition data.</string>
-	<key>NSHealthShareUsageDescription</key>
-	<string>Baseline reads your weight and body composition from Apple Health to display your trends.</string>
 	<key>NSHealthUpdateUsageDescription</key>
 	<string>Baseline writes your weight and body composition to Apple Health so other apps can access it.</string>
 	<key>UIBackgroundModes</key>

--- a/Baseline/Views/Settings/SettingsView.swift
+++ b/Baseline/Views/Settings/SettingsView.swift
@@ -362,7 +362,7 @@ struct SettingsView: View {
                 style: .info
             )
             SettingsDivider()
-            Link(destination: URL(string: "https://baseline.app/privacy")!) {
+            Link(destination: URL(string: "https://bgibso4.github.io/baseline/privacy/")!) {
                 SettingsRow(
                     icon: "shield",
                     label: "Privacy Policy",
@@ -371,7 +371,7 @@ struct SettingsView: View {
                 )
             }
             SettingsDivider()
-            Link(destination: URL(string: "https://baseline.app/terms")!) {
+            Link(destination: URL(string: "https://bgibso4.github.io/baseline/terms/")!) {
                 SettingsRow(
                     icon: "doc.text",
                     label: "Terms of Service",

--- a/docs/apple-requirements.md
+++ b/docs/apple-requirements.md
@@ -20,7 +20,7 @@ Legend: ✅ done · ⚠️ verify · ❌ missing
 |-----|--------|-------|
 | `com.apple.developer.healthkit` | ✅ | Enabled |
 | `com.apple.developer.healthkit.access` | ✅ | Empty array — standard HealthKit only, no clinical records |
-| `com.apple.developer.icloud-services` → `CloudKit` | ✅ | CloudDocuments removed 2026-04-19 — unused (no UIDocument/iCloud Drive path; photos sync via CloudKit external storage, CSV export uses system share sheet) |
+| `com.apple.developer.icloud-services` → `CloudKit` + `CloudDocuments` | ⚠️ | Both still present in `Baseline.entitlements` and `project.yml`. Doc previously claimed CloudDocuments was removed 2026-04-19 — that change did not actually land. Unused per audit: no `UIDocument`/iCloud Drive path; photos sync via CloudKit external storage; CSV export uses system share sheet. **Follow-up:** remove CloudDocuments in #41 (App Store review guidelines audit) — handle alongside other entitlement decisions. |
 | `com.apple.developer.icloud-container-identifiers` | ✅ | `iCloud.com.cadre.baseline` |
 | `com.apple.security.application-groups` | ✅ | `group.com.cadre.baseline` (shared with widget) |
 | `aps-environment` | n/a | Not required — CloudKit silent push via `NSPersistentCloudKitContainer` does not use APNs |
@@ -38,7 +38,7 @@ Legend: ✅ done · ⚠️ verify · ❌ missing
 | Capability | Status | Notes |
 |------------|--------|-------|
 | HealthKit | ✅ | Entitlement + usage strings present |
-| iCloud (CloudKit + CloudDocuments) | ✅ | Container identifier configured |
+| iCloud (CloudKit + CloudDocuments) | ⚠️ | Container identifier configured. CloudDocuments still present but unused — see entitlements note above. |
 | App Groups | ✅ | Shared between app and widget |
 | Background Modes → Remote notifications | ✅ | In `Baseline/Info.plist` — enables CloudKit silent push wake-ups |
 | Push Notifications | n/a | User-facing push not used in v1.0 |
@@ -51,7 +51,7 @@ Legend: ✅ done · ⚠️ verify · ❌ missing
 | Key | Status | Notes |
 |-----|--------|-------|
 | `NSCameraUsageDescription` | ✅ | "Baseline uses the camera to scan InBody printouts..." |
-| `NSHealthShareUsageDescription` | ✅ | Removed 2026-04-19 — `HealthKitManager` calls `requestAuthorization(toShare:, read: [])`, so read permission was never requested and the string was unused |
+| `NSHealthShareUsageDescription` | ✅ | Removed 2026-05-14 (issue #39 PR) — `HealthKitManager` calls `requestAuthorization(toShare:, read: [])`, so read permission was never requested and the string was unused. (Doc previously claimed removed 2026-04-19; that change did not actually land in `project.yml`.) |
 | `NSHealthUpdateUsageDescription` | ✅ | Matches stated write-only behaviour |
 | `NSPhotoLibraryUsageDescription` | n/a | No photo library access (scanner uses camera only) |
 | `NSUserTrackingUsageDescription` | n/a | No tracking — confirmed in privacy manifest |
@@ -94,6 +94,20 @@ Fill in App Store Connect during submission. Listed here so nothing is forgotten
 | App Review notes | Reuse `docs/APP_REVIEW_NOTES.md` |
 | Demo account | n/a — no sign-in |
 | Export compliance (in ASC) | Uses standard encryption, exempt. |
+| Privacy policy URL | `https://bgibso4.github.io/baseline/privacy/` — source in `gh-pages` branch. |
+| Terms of Service URL | `https://bgibso4.github.io/baseline/terms/` — source in `gh-pages` branch. Not required by Apple but used for the in-app "Not medical advice" disclaimer. |
+| Privacy contact email | `gibby.b12@gmail.com` |
+
+---
+
+## Legal pages
+
+Privacy Policy and Terms of Service are hosted on GitHub Pages from the `gh-pages` branch of this repo. Live URLs:
+
+- https://bgibso4.github.io/baseline/privacy/
+- https://bgibso4.github.io/baseline/terms/
+
+Both are linked from the app's Settings → About section (see `SettingsView.swift`). To edit, switch to the `gh-pages` branch, modify `privacy.md` or `terms.md`, bump the "Last updated" date at the top, and push. GitHub Pages rebuilds automatically within ~1 minute.
 
 ---
 
@@ -112,7 +126,8 @@ Fill in App Store Connect during submission. Listed here so nothing is forgotten
 
 1. **Required Reason API audit** — walk through Apple's list once before submission and add any new entries to `PrivacyInfo.xcprivacy`.
 2. **Final app icon** — blocker for TestFlight.
+3. **CloudDocuments entitlement removal** — still present in `project.yml` despite being unused. Bundle into #41 (App Store review guidelines audit).
 
 ---
 
-Last audited: 2026-04-19 (issue #19).
+Last audited: 2026-05-14 (issue #39 — privacy policy + ToS hosted, `NSHealthShareUsageDescription` actually removed).

--- a/project.yml
+++ b/project.yml
@@ -50,7 +50,6 @@ targets:
           - UIInterfaceOrientationPortrait
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
-        NSHealthShareUsageDescription: "Baseline reads your weight and body composition from Apple Health to display your trends."
         NSHealthUpdateUsageDescription: "Baseline writes your weight and body composition to Apple Health so other apps can access it."
         NSCameraUsageDescription: "Baseline uses the camera to scan InBody printouts and extract your body composition data."
         ITSAppUsesNonExemptEncryption: false


### PR DESCRIPTION
Closes #39.

## Summary

Stands up the Privacy Policy and Terms of Service required for App Store submission, hosted on GitHub Pages from a dedicated \`gh-pages\` branch, and wires the app's Settings → About links to the live URLs. Also folds in a small entitlement/Info.plist cleanup that was overdue.

## Live URLs

- 🛡️ Privacy Policy: https://bgibso4.github.io/baseline/privacy/
- 📄 Terms of Service: https://bgibso4.github.io/baseline/terms/
- 🏠 Landing: https://bgibso4.github.io/baseline/

All three respond 200 and were rendered by GitHub Pages (default \`jekyll-theme-minimal\` theme).

## Privacy Policy scope

Truthful to the public/App Store build's actual data flows:

- Body composition data lives on-device (SwiftData, iOS file encryption) and in the user's iCloud private DB (CloudKit, Apple-encrypted)
- HealthKit is write-only (\`requestAuthorization(toShare:, read: [])\`)
- OCR happens entirely on-device
- No analytics SDK (per #40 decision — closed)
- No third-party SDKs at all
- No accounts, no payments, no server we operate, no advertising, no tracking
- CSV export uses the system share sheet only
- Documents Apple App Analytics (aggregate, opt-in, controlled by Apple) as the only data flow we don't own

## Terms of Service scope

Short and aimed at the actual liability question for a body-comp tracker:

- **"Not medical advice"** disclaimer (the real reason ToS exists for this app)
- As-is / no-warranty
- User responsibility for accuracy + backups
- Acceptable use
- Right-to-update standard clause

## App-side changes

| File | Change |
|------|--------|
| \`Baseline/Views/Settings/SettingsView.swift\` | Privacy + Terms \`Link\` destinations now point to the live GitHub Pages URLs. Previously pointed at \`baseline.app/...\` — a domain we don't own (it's parked). |
| \`project.yml\` | Removed \`NSHealthShareUsageDescription\` (unused — \`HealthKitManager\` reads with \`read: []\`). \`apple-requirements.md\` had claimed this was removed on 2026-04-19 but the change had not actually landed. |
| \`Baseline/Info.plist\` | Regenerated by \`xcodegen\` to drop the removed key. |
| \`docs/apple-requirements.md\` | Records the new hosting + URLs + privacy contact email (\`gibby.b12@gmail.com\`). Corrects the stale \`NSHealthShareUsageDescription\` removal date. Flags \`CloudDocuments\` as still present in entitlements despite a similar prior removal claim — punted to #41 (App Store guidelines audit). |

## What is *not* in this PR

- **CloudDocuments entitlement removal.** Same drift pattern as the HealthShare description (doc claimed removed, actually still present). Staying scoped: separate entitlement change belongs alongside the rest of the #41 guidelines audit, not silently bundled into a docs/links PR.

## Test plan

- [x] \`xcodebuild build\` → \`** BUILD SUCCEEDED **\`
- [x] Site URLs return HTTP 200 (verified \`/\`, \`/privacy/\`, \`/terms/\`)
- [x] Rendered HTML contains expected content (TL;DR, last-updated date, contact email)
- [ ] Manual: open Settings → About in the app and tap each link — confirm they open Safari to the right URL
- [ ] Manual: on a test device with no Apple Health permissions yet, confirm the system permission sheet only asks for *write* access (no \`NSHealthShareUsageDescription\` prompt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)