### PR TITLE
feat: per-week rate in Trends hero for all metrics, drop date range

### DIFF
--- a/Baseline/Views/Trends/TrendsFormatting.swift
+++ b/Baseline/Views/Trends/TrendsFormatting.swift
@@ -20,23 +20,24 @@ enum TrendsFormatting {
         return formatted + " " + unit
     }
 
-    /// Builds the "Mar 6 – Apr 4 · -0.8 lb / week" string under the hero.
+    /// Builds the "−0.8 lb / week" rate string under the hero. The date range
+    /// is intentionally omitted — the window stepper already shows it. Sparse
+    /// windows (<7 points) report an entry count instead of a noisy rate.
     static func periodSubtitle(points: [TrendDataPoint], unit: String) -> String {
         guard let first = points.first, let last = points.last, points.count >= 2 else {
             return ""
         }
-        let spanDays = max(1, Calendar.current.dateComponents([.day], from: first.date, to: last.date).day ?? 1)
-        let dateRange = "\(DateFormatting.shortDay(first.date)) \u{2013} \(DateFormatting.shortDay(last.date))"
 
         if points.count < 7 {
-            return "\(dateRange) \u{00B7} \(points.count) entries"
+            return "\(points.count) entries"
         }
 
+        let spanDays = max(1, Calendar.current.dateComponents([.day], from: first.date, to: last.date).day ?? 1)
         let delta = last.value - first.value
         let weeks = Double(spanDays) / 7.0
         let perWeek = weeks > 0 ? delta / weeks : 0
         let perWeekStr = UnitConversion.formatDelta(perWeek)
             .replacingOccurrences(of: "-", with: "\u{2212}")
-        return "\(dateRange) \u{00B7} \(perWeekStr) \(unit) / week"
+        return "\(perWeekStr) \(unit) / week"
     }
 }

--- a/Baseline/Views/Trends/TrendsView.swift
+++ b/Baseline/Views/Trends/TrendsView.swift
@@ -504,9 +504,7 @@ struct TrendsView: View {
     // MARK: - Hero (latest value)
 
     private func heroBlock(latestValue: Double, unit: String, delta: Double, sub: String) -> some View {
-        let latestDate = vm?.dataPoints.last?.date
-
-        return VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: 8) {
             HStack(alignment: .firstTextBaseline, spacing: 6) {
                 Text(TrendsFormatting.value(latestValue))
                     .font(CadreTypography.trendsHero)
@@ -536,16 +534,13 @@ struct TrendsView: View {
             .lineLimit(1)
             .minimumScaleFactor(0.7)
 
-            // Date label for hero — "Today" or relative date for weight; period subtitle otherwise
-            if selectedMetric == .weight, let date = latestDate {
-                Text(heroRelativeDate(from: date))
-                    .font(CadreTypography.trendsHeroSub)
-                    .foregroundStyle(CadreColors.textTertiary)
-            } else {
-                Text(sub)
-                    .font(CadreTypography.trendsHeroSub)
-                    .foregroundStyle(CadreColors.textTertiary)
-            }
+            // Per-period rate subtitle (e.g. "−0.8 lb / week"), shown for every
+            // metric including weight. The date range is intentionally omitted —
+            // it's already conveyed by the window stepper. Sparse windows (<7
+            // entries) fall back to an entry count — see TrendsFormatting.
+            Text(sub)
+                .font(CadreTypography.trendsHeroSub)
+                .foregroundStyle(CadreColors.textTertiary)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }

--- a/BaselineTests/Views/TrendsFormattingTests.swift
+++ b/BaselineTests/Views/TrendsFormattingTests.swift
@@ -45,7 +45,8 @@ final class TrendsFormattingTests: XCTestCase {
             TrendDataPoint(date: base.addingTimeInterval(Double(i) * 86_400), value: 180)
         }
         let subtitle = TrendsFormatting.periodSubtitle(points: points, unit: "lb")
-        XCTAssertTrue(subtitle.hasSuffix("\u{00B7} 3 entries"), "got: \(subtitle)")
+        // Date range is omitted (the window stepper shows it); just the count.
+        XCTAssertEqual(subtitle, "3 entries")
     }
 
     func testPeriodSubtitleDenseShowsPerWeekRate() {
@@ -56,8 +57,9 @@ final class TrendsFormattingTests: XCTestCase {
             TrendDataPoint(date: base.addingTimeInterval(Double(i) * 86_400), value: 180 - Double(i))
         }
         // delta = 173 - 180 = -7 over 1 week → "−7.0 lb / week" (minus is U+2212).
+        // No date range — the window stepper conveys the span.
         let subtitle = TrendsFormatting.periodSubtitle(points: points, unit: "lb")
-        XCTAssertTrue(subtitle.hasSuffix("\u{00B7} \u{2212}7.0 lb / week"), "got: \(subtitle)")
+        XCTAssertEqual(subtitle, "\u{2212}7.0 lb / week")
         XCTAssertFalse(subtitle.contains("-"), "ASCII hyphen should be replaced with U+2212")
     }
 }


### PR DESCRIPTION
A UX tweak to the Trends hero sub-line, requested while verifying PR #84 on the simulator.

## Changes
- **Weight now shows the per-week rate** like every other metric. Previously weight was special-cased to show a relative date ("Today"); that branch is removed.
- **The date range is dropped from the subtitle.** It's redundant with the window stepper, which already shows the span. The sub-line is now just:
  - `−0.8 lb / week` for a full window (≥7 points)
  - `N entries` for a sparse window (<7 points — a weekly rate off a couple of points is noise)

Applies uniformly to weight, body measurements, and body-comp metrics.

## Why stacked on #84
`periodSubtitle` was extracted into `TrendsFormatting` (with unit tests) in #84. Basing this on that branch keeps the behavior change where the code now lives and lets me update the tests in lockstep, rather than conflicting with #84 at merge and leaving stale assertions. **Merge #84 first**, then this.

## Verification
- `make lint` — 0 violations (`--strict`)
- `make build` — succeeds
- `make test` — 266 logic (incl. updated `TrendsFormattingTests`) + 13 UI, all green
- Visually confirmed on the simulator

🤖 Generated with [Claude Code](https://claude.com/claude-code)