### PR TITLE
refactor: extract shared Trends chart leaves (axis scale + window stepper) (#80, pt 2a)

### DIFF
--- a/Baseline.xcodeproj/project.pbxproj
+++ b/Baseline.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		1EE8812183832C30DD541E19 /* BodyViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29BEDC0D79358B9B15F3738D /* BodyViewModelTests.swift */; };
 		21BB0A4DAE9AC51C0987DC67 /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A777911A4E98904254416624 /* SettingsViewModel.swift */; };
 		228218B4F80F12008965883E /* ImportCSVView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73CAFFE41BECB2DC306F2F26 /* ImportCSVView.swift */; };
+		2386907DB9434BCFC38713C4 /* TrendsWindowStepper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 597EE10F41B6F0E24F8F5796 /* TrendsWindowStepper.swift */; };
 		23A29B944BCD53F5BF416699 /* ThemePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA8445982F02B9AEE4F11AC /* ThemePickerView.swift */; };
 		251FFC2B4504866B32DDB194 /* testScanEntry_ManualForm.1.png in Resources */ = {isa = PBXBuildFile; fileRef = 8B2778585A57DC61D42C98DD /* testScanEntry_ManualForm.1.png */; };
 		25952DDEC892809F909C7E92 /* NowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C209CE8946DB31F979041D1A /* NowView.swift */; };
@@ -44,6 +45,7 @@
 		3E91E4B24AC961ADA451AEC8 /* ScanEntryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7163A3D21EC88D92F54DF5C7 /* ScanEntryViewModel.swift */; };
 		3F839DAE75B52120DDEB6224 /* CloudflareOutboundMirror.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA714D5002EBF0AEE77EE339 /* CloudflareOutboundMirror.swift */; };
 		416BB9FECD67376B100EFFAC /* BaselineWidgets.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = D25FD52DA7EFC4286FE7A191 /* BaselineWidgets.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		4177A44923D01345876EA403 /* TrendsAxisScaleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7762BE85D22561155559AE9E /* TrendsAxisScaleTests.swift */; };
 		41873906668FDCA091D71DC4 /* CloudKitSyncMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DFA854BB2DDD885AF4C12FC /* CloudKitSyncMonitor.swift */; };
 		42A19BCF838C00B2DEAFCEA2 /* CrossFieldValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB8EB95FB6A8252C1B9C10A5 /* CrossFieldValidatorTests.swift */; };
 		432827786CA2A6045E913872 /* CloudKitSyncMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB76F1D79684AF702D68282 /* CloudKitSyncMonitorTests.swift */; };
@@ -123,6 +125,7 @@
 		B7E9D155C81A13639FDC5C8B /* WeightLockScreenWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0070AF17E85C200AF4B68F44 /* WeightLockScreenWidget.swift */; };
 		B875B84190821E814AFBC1CF /* measurements-clean.csv in Resources */ = {isa = PBXBuildFile; fileRef = 3899BC53498DFB1744651ADA /* measurements-clean.csv */; };
 		B966B45973A0DD166B30FF6E /* ProcessingIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 059218AB9BEDF74190820B6C /* ProcessingIndicator.swift */; };
+		B9BD987ADCAFE01FF6BC1215 /* TrendsAxisScale.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EEA52343132DA148D0558C0 /* TrendsAxisScale.swift */; };
 		BB87D004E462B3E0D529401F /* testWeighInSheet_DarkMode_Default.1.png in Resources */ = {isa = PBXBuildFile; fileRef = E9A19626533DA8C2F89573FB /* testWeighInSheet_DarkMode_Default.1.png */; };
 		BDA863FA90D638092A5D0806 /* BaselineWidgets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CBC035387A8087081A7BDD0 /* BaselineWidgets.swift */; };
 		C10684A3EC9B98187CDBA383 /* SyncHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8044E19E7B426BDCE5DA9922 /* SyncHelper.swift */; };
@@ -219,6 +222,7 @@
 		1A36E8D666AC44FF62BE94B0 /* MetricPickerSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetricPickerSheet.swift; sourceTree = "<group>"; };
 		1AF6412F243C441BE0D8164E /* NowViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowViewModelTests.swift; sourceTree = "<group>"; };
 		1BF47DA1A29A20B42AE37685 /* testHistoryView_DarkMode_iPhone13Pro.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testHistoryView_DarkMode_iPhone13Pro.1.png; sourceTree = "<group>"; };
+		1EEA52343132DA148D0558C0 /* TrendsAxisScale.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrendsAxisScale.swift; sourceTree = "<group>"; };
 		2019690E1B79A00585C461C5 /* TestDataSeeder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestDataSeeder.swift; sourceTree = "<group>"; };
 		23809CFB7BDC7E7988734AE1 /* CrossFieldValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrossFieldValidator.swift; sourceTree = "<group>"; };
 		259F301EF2210DEFF2801026 /* testNowView_DarkMode_iPhone13Pro.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testNowView_DarkMode_iPhone13Pro.1.png; sourceTree = "<group>"; };
@@ -251,6 +255,7 @@
 		4F67EB45DA1DAE23E04AD404 /* TrendsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrendsView.swift; sourceTree = "<group>"; };
 		52A47437C87E1BCE8442A2FF /* BaselineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaselineTests.swift; sourceTree = "<group>"; };
 		53C81CF125885DB2F3C48C4D /* GradientBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradientBackground.swift; sourceTree = "<group>"; };
+		597EE10F41B6F0E24F8F5796 /* TrendsWindowStepper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrendsWindowStepper.swift; sourceTree = "<group>"; };
 		5998E990E3771B0504227A72 /* MetricHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetricHistoryView.swift; sourceTree = "<group>"; };
 		5A155E7245AEBA2E0B25A4FE /* IdentifierCoverageUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifierCoverageUITests.swift; sourceTree = "<group>"; };
 		5A9525A1638C18453603A9F6 /* UnitConversion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnitConversion.swift; sourceTree = "<group>"; };
@@ -280,6 +285,7 @@
 		74D5C40BED7A835BFB495376 /* ScanEntrySnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanEntrySnapshotTests.swift; sourceTree = "<group>"; };
 		763D6826C153150FDA57F2D4 /* BirthdayPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BirthdayPickerView.swift; sourceTree = "<group>"; };
 		76B6D911AF8339B62A988B99 /* MainTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
+		7762BE85D22561155559AE9E /* TrendsAxisScaleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrendsAxisScaleTests.swift; sourceTree = "<group>"; };
 		7A06A06DCC1BB86FD44CC36B /* testTrendsView_DarkMode_DefaultMonth.1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testTrendsView_DarkMode_DefaultMonth.1.png; sourceTree = "<group>"; };
 		7BD347427146045AA9060926 /* CSVExporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CSVExporterTests.swift; sourceTree = "<group>"; };
 		7C5711FD50AF3ED47B8906EC /* WeighInViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeighInViewModelTests.swift; sourceTree = "<group>"; };
@@ -485,11 +491,13 @@
 				D56B8A49CA2EEFD71F999494 /* LandscapeHostingController.swift */,
 				1A36E8D666AC44FF62BE94B0 /* MetricPickerSheet.swift */,
 				14BDE24DFB6B3F129FCF3288 /* SetGoalSheet.swift */,
+				1EEA52343132DA148D0558C0 /* TrendsAxisScale.swift */,
 				9AE4F7E6B06B896ACDCE236C /* TrendsEmptyState.swift */,
 				839715110C3FAAF23C21FEC6 /* TrendsFormatting.swift */,
 				056715019BB10989E9957B3F /* TrendsMetricChip.swift */,
 				60F4A3A18DF608B9A930B69B /* TrendsRangeTabs.swift */,
 				4F67EB45DA1DAE23E04AD404 /* TrendsView.swift */,
+				597EE10F41B6F0E24F8F5796 /* TrendsWindowStepper.swift */,
 			);
 			path = Trends;
 			sourceTree = "<group>";
@@ -689,6 +697,7 @@
 		8A0459F3248EB001ED19FBBE /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				7762BE85D22561155559AE9E /* TrendsAxisScaleTests.swift */,
 				18D1E4F3B7929952CCB9DC39 /* TrendsFormattingTests.swift */,
 			);
 			path = Views;
@@ -1078,6 +1087,7 @@
 				8A6C14E968F3488B503E757A /* SettingsViewSnapshotTests.swift in Sources */,
 				DF1C2AAE4960B545734FBBF9 /* SpyHealthKitMirror.swift in Sources */,
 				B0D43F34C8EE9668DE7AC1FB /* TestDataSeederProfileTests.swift in Sources */,
+				4177A44923D01345876EA403 /* TrendsAxisScaleTests.swift in Sources */,
 				ECD711A9E493D3D05A799EC5 /* TrendsFormattingTests.swift in Sources */,
 				44407861EB6DA9740AE44A5E /* TrendsViewModelTests.swift in Sources */,
 				0BAB7EB581FEBEC95104DC1E /* TrendsViewSnapshotTests.swift in Sources */,
@@ -1162,12 +1172,14 @@
 				B75C84191E094A7A6442247B /* SyncState.swift in Sources */,
 				1D2B86EC0CD2F6E04169B12A /* TestDataSeeder.swift in Sources */,
 				23A29B944BCD53F5BF416699 /* ThemePickerView.swift in Sources */,
+				B9BD987ADCAFE01FF6BC1215 /* TrendsAxisScale.swift in Sources */,
 				D2CE6821E9157B5797CF0A5C /* TrendsEmptyState.swift in Sources */,
 				B1B7B64D0818BF5630B0C03D /* TrendsFormatting.swift in Sources */,
 				27AA6028031EB34B8ADFAAF9 /* TrendsMetricChip.swift in Sources */,
 				D471AFFD6332E1E2F8FF6B21 /* TrendsRangeTabs.swift in Sources */,
 				353ED107DFB67E0B0D3C0B01 /* TrendsView.swift in Sources */,
 				921D43A164E135DC0C85E731 /* TrendsViewModel.swift in Sources */,
+				2386907DB9434BCFC38713C4 /* TrendsWindowStepper.swift in Sources */,
 				92B02A5AE4EBA1597947A801 /* UnitConversion.swift in Sources */,
 				E9AE862F20C7238325BF97E0 /* WeighInSheet.swift in Sources */,
 				D3355A1D414FF7C657BCF5A7 /* WeighInViewModel.swift in Sources */,

--- a/Baseline/Views/Trends/TrendsAxisScale.swift
+++ b/Baseline/Views/Trends/TrendsAxisScale.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// Pure dual-axis math for the Trends charts. Extracted from `TrendsView` so
+/// the normalization and tick-value logic is testable without rendering
+/// SwiftUI (see `TrendsAxisScaleTests`). Used by both the inline and
+/// fullscreen charts when a secondary metric on a different scale is overlaid.
+enum TrendsAxisScale {
+    /// Normalize a value into the 0–1 range given a min/max. Returns 0.5 if the
+    /// range is zero (degenerate single-value series).
+    static func normalize(_ value: Double, min: Double, max: Double) -> Double {
+        guard max - min > 0 else { return 0.5 }
+        return (value - min) / (max - min)
+    }
+
+    /// Compute `count` evenly-spaced real-value tick labels across a min/max
+    /// range. Returns `[min]` for a zero-width range.
+    static func axisTickValues(min: Double, max: Double, count: Int = 4) -> [Double] {
+        guard max - min > 0 else { return [min] }
+        return (0..<count).map { i in
+            min + (max - min) * Double(i) / Double(count - 1)
+        }
+    }
+}

--- a/Baseline/Views/Trends/TrendsView.swift
+++ b/Baseline/Views/Trends/TrendsView.swift
@@ -298,85 +298,10 @@ struct TrendsView: View {
         let hideStepper = (vm?.timeRange ?? .month) == .all
         return hero
             .overlay(alignment: .bottomTrailing) {
-                windowNavRow
+                TrendsWindowStepper(vm: vm, onStep: { inlineSelectedDate = nil })
                     .opacity(hideStepper ? 0 : 1)
                     .allowsHitTesting(!hideStepper)
             }
-    }
-
-    // MARK: - Window stepper (#62 — Whoop-style nav)
-
-    /// Compact chevron-left/label/chevron-right row pinned inside the chart
-    /// card (top-right above the graph). Lets the user step backward and
-    /// forward through windows of the selected time range. Hidden for
-    /// `.all` because there's only one window.
-    private var windowNavRow: some View {
-        HStack(spacing: 4) {
-            Button {
-                withAnimation(.snappy(duration: 0.25)) {
-                    vm?.stepWindow(by: -1)
-                    inlineSelectedDate = nil
-                    vm?.refresh()
-                }
-                Haptics.selection()
-            } label: {
-                Image(systemName: "chevron.left")
-                    .font(.system(size: 11, weight: .bold))
-                    .foregroundStyle(
-                        (vm?.canStepBackward ?? false)
-                            ? CadreColors.textSecondary
-                            : CadreColors.textTertiary.opacity(0.3)
-                    )
-                    .frame(minWidth: 44, minHeight: 44)
-                    .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-            .disabled(!(vm?.canStepBackward ?? false))
-            .accessibilityLabel("Previous period")
-            .accessibilityIdentifier(A11yID.Trends.windowStepBack)
-
-            Text(vm?.currentWindowLabel ?? "")
-                // Use semantic .caption so Dynamic Type audit recognises this
-                // as fully scalable. .caption (12pt default) is the smallest
-                // style that passes; .caption2 (11pt) with weight modifier
-                // causes a tool false-positive. Previously .system(size:10)
-                // was non-scalable and caused a DT "unsupported" failure.
-                .font(.caption.weight(.bold))
-                .tracking(0.5)
-                .foregroundStyle(CadreColors.textPrimary)
-                .contentTransition(.numericText())
-                .animation(.snappy, value: vm?.windowEndDate)
-                .lineLimit(1)
-                .fixedSize()
-                // Hide from accessibility when the label is empty (no-data state)
-                // to prevent "label not human-readable" audit failure for an
-                // empty-string StaticText.
-                .accessibilityHidden((vm?.currentWindowLabel ?? "").isEmpty)
-
-            Button {
-                withAnimation(.snappy(duration: 0.25)) {
-                    vm?.stepWindow(by: 1)
-                    inlineSelectedDate = nil
-                    vm?.refresh()
-                }
-                Haptics.selection()
-            } label: {
-                Image(systemName: "chevron.right")
-                    .font(.system(size: 11, weight: .bold))
-                    .foregroundStyle(
-                        (vm?.canStepForward ?? false)
-                            ? CadreColors.textSecondary
-                            : CadreColors.textTertiary.opacity(0.3)
-                    )
-                    .frame(minWidth: 44, minHeight: 44)
-                    .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-            .disabled(!(vm?.canStepForward ?? false))
-            .accessibilityLabel("Next period")
-            .accessibilityIdentifier(A11yID.Trends.windowStepForward)
-        }
-        .padding(.horizontal, 4)
     }
 
     // MARK: - Full variant (2+ data points)
@@ -700,13 +625,7 @@ struct TrendsView: View {
         return DateFormatting.shortDay(date)
     }
 
-    // MARK: - Dual-axis normalization helpers
-
-    /// Normalize a value into 0–1 range given a min/max. Returns 0.5 if range is zero.
-    private func normalize(_ value: Double, min: Double, max: Double) -> Double {
-        guard max - min > 0 else { return 0.5 }
-        return (value - min) / (max - min)
-    }
+    // MARK: - Dual-axis helper
 
     /// Whether dual-axis normalization is needed (compare active with a different metric).
     /// Previous period uses the same scale, so no normalization needed.
@@ -717,14 +636,6 @@ struct TrendsView: View {
         // Previous period compare is same metric → same scale → no dual axis
         if previousPeriod != nil { return false }
         return true
-    }
-
-    /// Compute 4 evenly-spaced real-value tick labels for a given min/max range.
-    private func axisTickValues(min: Double, max: Double, count: Int = 4) -> [Double] {
-        guard max - min > 0 else { return [min] }
-        return (0..<count).map { i in
-            min + (max - min) * Double(i) / Double(count - 1)
-        }
     }
 
     // MARK: - Chart (Swift Charts)
@@ -773,7 +684,9 @@ struct TrendsView: View {
         let chart = Chart {
             if showRawLine {
                 ForEach(points) { point in
-                    let yVal = dualAxis ? normalize(point.value, min: primaryMin, max: primaryMax) : point.value
+                    let yVal = dualAxis
+                        ? TrendsAxisScale.normalize(point.value, min: primaryMin, max: primaryMax)
+                        : point.value
                     LineMark(
                         x: .value("Date", point.date),
                         y: .value("Value", yVal),
@@ -785,7 +698,9 @@ struct TrendsView: View {
             }
             if showRawDots {
                 ForEach(points) { point in
-                    let yVal = dualAxis ? normalize(point.value, min: primaryMin, max: primaryMax) : point.value
+                    let yVal = dualAxis
+                        ? TrendsAxisScale.normalize(point.value, min: primaryMin, max: primaryMax)
+                        : point.value
                     PointMark(
                         x: .value("Date", point.date),
                         y: .value("Value", yVal)
@@ -795,7 +710,9 @@ struct TrendsView: View {
                 }
             }
             ForEach(movingAverage) { point in
-                let yVal = dualAxis ? normalize(point.value, min: primaryMin, max: primaryMax) : point.value
+                let yVal = dualAxis
+                    ? TrendsAxisScale.normalize(point.value, min: primaryMin, max: primaryMax)
+                    : point.value
                 LineMark(
                     x: .value("Date", point.date),
                     y: .value("MA", yVal),
@@ -808,7 +725,7 @@ struct TrendsView: View {
             // Secondary metric (compare mode)
             if compareEnabled && !secondaryPoints.isEmpty {
                 ForEach(secondaryPoints) { point in
-                    let yVal = dualAxis ? normalize(point.value, min: secMin, max: secMax) : point.value
+                    let yVal = dualAxis ? TrendsAxisScale.normalize(point.value, min: secMin, max: secMax) : point.value
                     PointMark(
                         x: .value("Date", point.date),
                         y: .value("Value", yVal)
@@ -817,7 +734,7 @@ struct TrendsView: View {
                     .symbolSize(30)
                 }
                 ForEach(secondaryPoints) { point in
-                    let yVal = dualAxis ? normalize(point.value, min: secMin, max: secMax) : point.value
+                    let yVal = dualAxis ? TrendsAxisScale.normalize(point.value, min: secMin, max: secMax) : point.value
                     LineMark(
                         x: .value("Date", point.date),
                         y: .value("Value", yVal),
@@ -857,8 +774,8 @@ struct TrendsView: View {
         .chartYAxis {
             if dualAxis {
                 // Right axis: primary metric real values (stays on trailing like single-metric)
-                let primaryTicks = axisTickValues(min: primaryMin, max: primaryMax)
-                    .map { normalize($0, min: primaryMin, max: primaryMax) }
+                let primaryTicks = TrendsAxisScale.axisTickValues(min: primaryMin, max: primaryMax)
+                    .map { TrendsAxisScale.normalize($0, min: primaryMin, max: primaryMax) }
                 AxisMarks(position: .trailing, values: primaryTicks) { mark in
                     AxisGridLine()
                         .foregroundStyle(CadreColors.chartGrid)
@@ -871,7 +788,8 @@ struct TrendsView: View {
                     }
                 }
                 // Left axis: secondary metric real values
-                let secTicks = axisTickValues(min: secMin, max: secMax).map { normalize($0, min: secMin, max: secMax) }
+                let secTicks = TrendsAxisScale.axisTickValues(min: secMin, max: secMax)
+                    .map { TrendsAxisScale.normalize($0, min: secMin, max: secMax) }
                 AxisMarks(position: .leading, values: secTicks) { mark in
                     AxisValueLabel {
                         let norm = mark.as(Double.self) ?? 0
@@ -1322,7 +1240,7 @@ struct TrendsView: View {
                     VStack(spacing: 6) {
                         HStack {
                             Spacer()
-                            windowNavRow
+                            TrendsWindowStepper(vm: vm, onStep: { fullscreenSelectedDate = nil })
                             Spacer()
                         }
                         .opacity(fsHideStepper ? 0 : 1)
@@ -1335,7 +1253,8 @@ struct TrendsView: View {
                         if fsShowRawLine {
                             ForEach(points) { point in
                                 let yVal = fsDualAxis
-                                    ? normalize(point.value, min: fsPrimaryMin, max: fsPrimaryMax) : point.value
+                                    ? TrendsAxisScale.normalize(point.value, min: fsPrimaryMin, max: fsPrimaryMax)
+                                    : point.value
                                 LineMark(
                                     x: .value("Date", point.date),
                                     y: .value("Value", yVal),
@@ -1348,7 +1267,8 @@ struct TrendsView: View {
                         if fsShowRawDots {
                             ForEach(points) { point in
                                 let yVal = fsDualAxis
-                                    ? normalize(point.value, min: fsPrimaryMin, max: fsPrimaryMax) : point.value
+                                    ? TrendsAxisScale.normalize(point.value, min: fsPrimaryMin, max: fsPrimaryMax)
+                                    : point.value
                                 PointMark(
                                     x: .value("Date", point.date),
                                     y: .value("Value", yVal)
@@ -1359,7 +1279,8 @@ struct TrendsView: View {
                         }
                         ForEach(ma) { point in
                             let yVal = fsDualAxis
-                                ? normalize(point.value, min: fsPrimaryMin, max: fsPrimaryMax) : point.value
+                                ? TrendsAxisScale.normalize(point.value, min: fsPrimaryMin, max: fsPrimaryMax)
+                                : point.value
                             LineMark(
                                 x: .value("Date", point.date),
                                 y: .value("MA", yVal),
@@ -1373,7 +1294,7 @@ struct TrendsView: View {
                         if hasSecondary {
                             ForEach(secondaryPoints) { point in
                                 let yVal = fsDualAxis
-                                    ? normalize(point.value, min: fsSecMin, max: fsSecMax) : point.value
+                                    ? TrendsAxisScale.normalize(point.value, min: fsSecMin, max: fsSecMax) : point.value
                                 PointMark(
                                     x: .value("Date", point.date),
                                     y: .value("Value", yVal)
@@ -1383,7 +1304,7 @@ struct TrendsView: View {
                             }
                             ForEach(secondaryPoints) { point in
                                 let yVal = fsDualAxis
-                                    ? normalize(point.value, min: fsSecMin, max: fsSecMax) : point.value
+                                    ? TrendsAxisScale.normalize(point.value, min: fsSecMin, max: fsSecMax) : point.value
                                 LineMark(
                                     x: .value("Date", point.date),
                                     y: .value("Value", yVal),
@@ -1405,8 +1326,8 @@ struct TrendsView: View {
                     }
                     .chartYAxis {
                         if fsDualAxis {
-                            let fsPrimaryTicks = axisTickValues(min: fsPrimaryMin, max: fsPrimaryMax)
-                                .map { normalize($0, min: fsPrimaryMin, max: fsPrimaryMax) }
+                            let fsPrimaryTicks = TrendsAxisScale.axisTickValues(min: fsPrimaryMin, max: fsPrimaryMax)
+                                .map { TrendsAxisScale.normalize($0, min: fsPrimaryMin, max: fsPrimaryMax) }
                             AxisMarks(position: .trailing, values: fsPrimaryTicks) { mark in
                                 AxisGridLine()
                                     .foregroundStyle(CadreColors.chartGrid)
@@ -1418,8 +1339,8 @@ struct TrendsView: View {
                                         .font(CadreTypography.trendsAxisLabel)
                                 }
                             }
-                            let fsSecTicks = axisTickValues(min: fsSecMin, max: fsSecMax)
-                                .map { normalize($0, min: fsSecMin, max: fsSecMax) }
+                            let fsSecTicks = TrendsAxisScale.axisTickValues(min: fsSecMin, max: fsSecMax)
+                                .map { TrendsAxisScale.normalize($0, min: fsSecMin, max: fsSecMax) }
                             AxisMarks(position: .leading, values: fsSecTicks) { mark in
                                 AxisValueLabel {
                                     let norm = mark.as(Double.self) ?? 0

--- a/Baseline/Views/Trends/TrendsWindowStepper.swift
+++ b/Baseline/Views/Trends/TrendsWindowStepper.swift
@@ -1,0 +1,83 @@
+import SwiftUI
+
+/// Compact chevron-left / label / chevron-right row (#62 — Whoop-style nav)
+/// that steps backward and forward through windows of the selected time range.
+/// Hidden by the caller for the `.all` range (only one window).
+///
+/// Shared by the inline and fullscreen charts. Presentational: it drives the
+/// view model's window stepping and reports each step via `onStep`, so the
+/// caller can clear its own crosshair selection (inline vs fullscreen own
+/// separate selection state).
+struct TrendsWindowStepper: View {
+    let vm: TrendsViewModel?
+    let onStep: () -> Void
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Button {
+                withAnimation(.snappy(duration: 0.25)) {
+                    vm?.stepWindow(by: -1)
+                    onStep()
+                    vm?.refresh()
+                }
+                Haptics.selection()
+            } label: {
+                Image(systemName: "chevron.left")
+                    .font(.system(size: 11, weight: .bold))
+                    .foregroundStyle(
+                        (vm?.canStepBackward ?? false)
+                            ? CadreColors.textSecondary
+                            : CadreColors.textTertiary.opacity(0.3)
+                    )
+                    .frame(minWidth: 44, minHeight: 44)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .disabled(!(vm?.canStepBackward ?? false))
+            .accessibilityLabel("Previous period")
+            .accessibilityIdentifier(A11yID.Trends.windowStepBack)
+
+            Text(vm?.currentWindowLabel ?? "")
+                // Use semantic .caption so Dynamic Type audit recognises this
+                // as fully scalable. .caption (12pt default) is the smallest
+                // style that passes; .caption2 (11pt) with weight modifier
+                // causes a tool false-positive. Previously .system(size:10)
+                // was non-scalable and caused a DT "unsupported" failure.
+                .font(.caption.weight(.bold))
+                .tracking(0.5)
+                .foregroundStyle(CadreColors.textPrimary)
+                .contentTransition(.numericText())
+                .animation(.snappy, value: vm?.windowEndDate)
+                .lineLimit(1)
+                .fixedSize()
+                // Hide from accessibility when the label is empty (no-data state)
+                // to prevent "label not human-readable" audit failure for an
+                // empty-string StaticText.
+                .accessibilityHidden((vm?.currentWindowLabel ?? "").isEmpty)
+
+            Button {
+                withAnimation(.snappy(duration: 0.25)) {
+                    vm?.stepWindow(by: 1)
+                    onStep()
+                    vm?.refresh()
+                }
+                Haptics.selection()
+            } label: {
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 11, weight: .bold))
+                    .foregroundStyle(
+                        (vm?.canStepForward ?? false)
+                            ? CadreColors.textSecondary
+                            : CadreColors.textTertiary.opacity(0.3)
+                    )
+                    .frame(minWidth: 44, minHeight: 44)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .disabled(!(vm?.canStepForward ?? false))
+            .accessibilityLabel("Next period")
+            .accessibilityIdentifier(A11yID.Trends.windowStepForward)
+        }
+        .padding(.horizontal, 4)
+    }
+}

--- a/BaselineTests/Views/TrendsAxisScaleTests.swift
+++ b/BaselineTests/Views/TrendsAxisScaleTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+@testable import Baseline
+
+final class TrendsAxisScaleTests: XCTestCase {
+
+    // MARK: - normalize
+
+    func testNormalizeMapsRangeToZeroOne() {
+        XCTAssertEqual(TrendsAxisScale.normalize(0, min: 0, max: 10), 0.0, accuracy: 1e-9)
+        XCTAssertEqual(TrendsAxisScale.normalize(5, min: 0, max: 10), 0.5, accuracy: 1e-9)
+        XCTAssertEqual(TrendsAxisScale.normalize(10, min: 0, max: 10), 1.0, accuracy: 1e-9)
+    }
+
+    func testNormalizeHandlesNonZeroFloor() {
+        XCTAssertEqual(TrendsAxisScale.normalize(150, min: 100, max: 200), 0.5, accuracy: 1e-9)
+    }
+
+    func testNormalizeZeroWidthRangeReturnsMidpoint() {
+        // Degenerate range (single value) → 0.5 so the point sits centered.
+        XCTAssertEqual(TrendsAxisScale.normalize(180, min: 180, max: 180), 0.5, accuracy: 1e-9)
+    }
+
+    // MARK: - axisTickValues
+
+    func testAxisTickValuesEvenlySpaced() {
+        let ticks = TrendsAxisScale.axisTickValues(min: 0, max: 30, count: 4)
+        XCTAssertEqual(ticks, [0, 10, 20, 30])
+    }
+
+    func testAxisTickValuesDefaultCountIsFour() {
+        XCTAssertEqual(TrendsAxisScale.axisTickValues(min: 0, max: 30).count, 4)
+    }
+
+    func testAxisTickValuesZeroWidthRangeReturnsSingle() {
+        XCTAssertEqual(TrendsAxisScale.axisTickValues(min: 5, max: 5), [5])
+    }
+}


### PR DESCRIPTION
First of three steps decomposing TrendsView's chart cluster (continuing #80 after the pt-1 header/empty/formatting extraction in #84). The inline and fullscreen charts share two pieces — extracting them first removes the coupling knot so each chart view can depend on shared components cleanly in 2b/2c.

## Extracted
- **`TrendsAxisScale.swift`** — `normalize` + `axisTickValues` as pure static funcs, now **unit-tested** (`TrendsAxisScaleTests`, 6 cases). Used by both charts for dual-axis rendering.
- **`TrendsWindowStepper.swift`** — the window-nav row (#62) as a presentational component. It drives the VM's window stepping and reports each step via an `onStep` closure, so the inline and fullscreen charts each clear *their own* crosshair selection. (Previously `windowNavRow` hard-coded `inlineSelectedDate = nil`, which was actually wrong for the fullscreen caller — this fixes that latent coupling.)

`needsDualAxis` stays in `TrendsView` for now (only the inline chart uses it; it moves with the chart in 2c).

`TrendsView.swift`: **1496 → 1407 lines.**

## Behavior & thresholds
No behavior change. Thresholds unchanged — `TrendsView` still dominates `file_length`/`type_body_length` until the chart itself moves (2c).

## Verification
- `make lint` — 0 violations (`--strict`)
- `make build` — succeeds
- `make test` — 272 logic (incl. new `TrendsAxisScaleTests`) + 13 UI, all green. The UI tests exercise the window stepper (`windowStepBack`/`windowStepForward`), so the presentational extraction is verified behavior-identical.

Part of #80. Followed by 2b (fullscreen chart) and 2c (inline chart section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)