### PR TITLE
refactor: split SettingsView into focused components (#80)

### DIFF
--- a/Baseline.xcodeproj/project.pbxproj
+++ b/Baseline.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		6254329CEF5CC3D67463C0A9 /* WeighInFlowUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16730365FDF8FF1CA83F6B18 /* WeighInFlowUITests.swift */; };
 		64D85461FED8886808120A2C /* IdentifierCoverageUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A155E7245AEBA2E0B25A4FE /* IdentifierCoverageUITests.swift */; };
 		65A61217D0DEF001C4BC19A2 /* Haptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = E22A1EED058DA9647318A9C3 /* Haptics.swift */; };
+		6A88BEDC87718BA92F1334CD /* SettingsHealthSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A81C4F273D6A07EAFB6E4BE4 /* SettingsHealthSection.swift */; };
 		6AC1FE662BB8374653D0EDD0 /* testNowView_DarkMode_iPhone13Pro.1.png in Resources */ = {isa = PBXBuildFile; fileRef = 259F301EF2210DEFF2801026 /* testNowView_DarkMode_iPhone13Pro.1.png */; };
 		6BBDD1DD96A9F0499A3C8920 /* GenderPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843927F5802EBFD67BB78972 /* GenderPickerView.swift */; };
 		6D21F2F3E9165259496B8558 /* SmokeNavigationUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A65E20481955BDBBED48A166 /* SmokeNavigationUITests.swift */; };
@@ -122,8 +123,10 @@
 		A57EEB8655AA931F183DCC5A /* ScanHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44F25E2DF4D4198F90CBFA5F /* ScanHistoryView.swift */; };
 		A9E1A4B3AF560272E604B288 /* GoalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C6E3FC3B8CEA3502EDE634C /* GoalTests.swift */; };
 		AC6455D3A0B6E99A6B9B613D /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = D2EB71FC82094D506CFDCC73 /* PrivacyInfo.xcprivacy */; };
+		AE29CA11A07D6A447F00515A /* SettingsDeveloperSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = F512DF8CAB9CFB8E2FDD5DB9 /* SettingsDeveloperSection.swift */; };
 		AE4F08FFC7E7366D526B7FE5 /* CadreTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D4F5BD3681AD8577A6A3B0C /* CadreTokens.swift */; };
 		AEC89CED080102D131D1EB45 /* CrossFieldValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23809CFB7BDC7E7988734AE1 /* CrossFieldValidator.swift */; };
+		AFEED3FBF53EA760CC11BDC3 /* SettingsComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54946674C3DE4E3B9DA9DB50 /* SettingsComponents.swift */; };
 		B0D43F34C8EE9668DE7AC1FB /* TestDataSeederProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 305D48B82A09CA4E0E7BCD0E /* TestDataSeederProfileTests.swift */; };
 		B1B7B64D0818BF5630B0C03D /* TrendsFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 839715110C3FAAF23C21FEC6 /* TrendsFormatting.swift */; };
 		B2569C22E105546FCDA1C27F /* LaunchConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6770CFB7DCF2340E1E0C6D09 /* LaunchConfigurationTests.swift */; };
@@ -269,6 +272,7 @@
 		4F67EB45DA1DAE23E04AD404 /* TrendsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrendsView.swift; sourceTree = "<group>"; };
 		52A47437C87E1BCE8442A2FF /* BaselineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaselineTests.swift; sourceTree = "<group>"; };
 		53C81CF125885DB2F3C48C4D /* GradientBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradientBackground.swift; sourceTree = "<group>"; };
+		54946674C3DE4E3B9DA9DB50 /* SettingsComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsComponents.swift; sourceTree = "<group>"; };
 		597EE10F41B6F0E24F8F5796 /* TrendsWindowStepper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrendsWindowStepper.swift; sourceTree = "<group>"; };
 		5998E990E3771B0504227A72 /* MetricHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetricHistoryView.swift; sourceTree = "<group>"; };
 		5A155E7245AEBA2E0B25A4FE /* IdentifierCoverageUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifierCoverageUITests.swift; sourceTree = "<group>"; };
@@ -337,6 +341,7 @@
 		A6C5F86354C722884254D09A /* BaselineTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = BaselineTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A777911A4E98904254416624 /* SettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
 		A7C2B8129886E8A1210694D6 /* AboutCadreView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutCadreView.swift; sourceTree = "<group>"; };
+		A81C4F273D6A07EAFB6E4BE4 /* SettingsHealthSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsHealthSection.swift; sourceTree = "<group>"; };
 		AB289EC0E5CC9756E1B62116 /* UnitConversionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnitConversionTests.swift; sourceTree = "<group>"; };
 		AB8EB95FB6A8252C1B9C10A5 /* CrossFieldValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrossFieldValidatorTests.swift; sourceTree = "<group>"; };
 		ACDA43306F3BC25054A85ABE /* weights-slash-dates-split-time.csv */ = {isa = PBXFileReference; path = "weights-slash-dates-split-time.csv"; sourceTree = "<group>"; };
@@ -384,6 +389,7 @@
 		F33E3CB74C4DCE41C764260D /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		F48EFFC280B6AF1B4D90AADE /* MetricTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetricTile.swift; sourceTree = "<group>"; };
 		F4B62AE88FB82E485614E3D0 /* Scan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Scan.swift; sourceTree = "<group>"; };
+		F512DF8CAB9CFB8E2FDD5DB9 /* SettingsDeveloperSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsDeveloperSection.swift; sourceTree = "<group>"; };
 		F9E0701D264BBEE3B1833E0D /* ScanDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanDetailView.swift; sourceTree = "<group>"; };
 		FD2CAB65EF5D09191212579A /* ScanTypeStep.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanTypeStep.swift; sourceTree = "<group>"; };
 		FD91A7FB375167742BA11341 /* APIClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientTests.swift; sourceTree = "<group>"; };
@@ -567,6 +573,9 @@
 				DEC16C51DFDA91FA7489EA4A /* HeightPickerView.swift */,
 				73CAFFE41BECB2DC306F2F26 /* ImportCSVView.swift */,
 				264D3E45024F3979CE10462A /* NameEditView.swift */,
+				54946674C3DE4E3B9DA9DB50 /* SettingsComponents.swift */,
+				F512DF8CAB9CFB8E2FDD5DB9 /* SettingsDeveloperSection.swift */,
+				A81C4F273D6A07EAFB6E4BE4 /* SettingsHealthSection.swift */,
 				F33E3CB74C4DCE41C764260D /* SettingsView.swift */,
 				BEA8445982F02B9AEE4F11AC /* ThemePickerView.swift */,
 			);
@@ -1215,6 +1224,9 @@
 				3A26E7683F4A65D4A9240FE8 /* ScanPayloads.swift in Sources */,
 				7B54306329FD9740F64ECD42 /* ScanTypeStep.swift in Sources */,
 				60FB5F4F8D87A751246CF146 /* SetGoalSheet.swift in Sources */,
+				AFEED3FBF53EA760CC11BDC3 /* SettingsComponents.swift in Sources */,
+				AE29CA11A07D6A447F00515A /* SettingsDeveloperSection.swift in Sources */,
+				6A88BEDC87718BA92F1334CD /* SettingsHealthSection.swift in Sources */,
 				9DDDD276C649F100FFF941FE /* SettingsView.swift in Sources */,
 				21BB0A4DAE9AC51C0987DC67 /* SettingsViewModel.swift in Sources */,
 				905B4B275BC4613C047A33A6 /* SparklineView.swift in Sources */,

--- a/Baseline/Views/Settings/SettingsComponents.swift
+++ b/Baseline/Views/Settings/SettingsComponents.swift
@@ -1,0 +1,216 @@
+import SwiftUI
+
+// MARK: - Supporting Components
+
+/// Row display style determines trailing accessory.
+enum SettingsRowStyle {
+    case push
+    /// Push row that is an action (no "Not set" fallback when value is nil).
+    case action
+    case info
+    case externalLink
+    case danger
+    case badge(String)
+}
+
+/// Tint override for row icons.
+enum SettingsIconTint {
+    case accent
+    case secondary
+    case success
+    case danger
+}
+
+/// Reusable settings row — icon + label + optional value + trailing accessory.
+struct SettingsRow: View {
+    let icon: String
+    let label: String
+    let value: String?
+    let style: SettingsRowStyle
+    var iconTint: SettingsIconTint = .accent
+
+    var body: some View {
+        HStack(spacing: 14) {
+            SettingsRowIcon(systemName: icon, tint: iconTint)
+
+            // .subheadline (15pt default) matches the original 14pt design intent
+            // while enabling Dynamic Type scaling for accessibility compliance.
+            Text(label)
+                .font(.subheadline.weight(.medium))
+                .foregroundStyle(style.labelColor)
+                .tracking(-0.1)
+
+            Spacer()
+
+            // Value or trailing accessory
+            switch style {
+            case .push:
+                if let value {
+                    // .footnote (13pt default) matches the original 13pt value text.
+                    Text(value)
+                        .font(.footnote.weight(.medium))
+                        .foregroundStyle(CadreColors.textSecondary)
+                } else {
+                    Text("Not set")
+                        .font(.footnote.weight(.medium))
+                        .foregroundStyle(CadreColors.textTertiary)
+                }
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(CadreColors.textTertiary)
+
+            case .action:
+                if let value {
+                    Text(value)
+                        .font(.footnote.weight(.medium))
+                        .foregroundStyle(CadreColors.textSecondary)
+                }
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(CadreColors.textTertiary)
+
+            case .info:
+                if let value {
+                    Text(value)
+                        .font(.footnote.weight(.medium))
+                        .foregroundStyle(CadreColors.textSecondary)
+                }
+
+            case .externalLink:
+                Image(systemName: "arrow.up.right")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(CadreColors.textTertiary)
+
+            case .danger:
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(CadreColors.danger.opacity(0.6))
+
+            case .badge(let text):
+                Text(text)
+                    // .caption (12pt) passes DT audit; .caption2 (11pt) with weight
+                    // modifier causes a tool false-positive ("partially unsupported").
+                    .font(.caption.weight(.bold))
+                    .textCase(.uppercase)
+                    .tracking(0.4)
+                    .foregroundStyle(CadreColors.textTertiary)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 3)
+                    .background(CadreColors.cardElevated, in: RoundedRectangle(cornerRadius: 5))
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
+        .contentShape(Rectangle())
+    }
+}
+
+private extension SettingsRowStyle {
+    var labelColor: Color {
+        switch self {
+        case .danger: return CadreColors.danger
+        default: return CadreColors.textPrimary
+        }
+    }
+}
+
+/// 28pt rounded-rect icon container matching the mockup `.row .row-icon`.
+struct SettingsRowIcon: View {
+    let systemName: String
+    var tint: SettingsIconTint = .accent
+
+    var body: some View {
+        Image(systemName: systemName)
+            .font(.system(size: 15, weight: .medium))
+            .foregroundStyle(tint.color)
+            .frame(width: 28, height: 28)
+            .background(CadreColors.cardElevated, in: RoundedRectangle(cornerRadius: 8))
+    }
+}
+
+private extension SettingsIconTint {
+    var color: Color {
+        switch self {
+        case .accent: return CadreColors.accent
+        case .secondary: return Color(hex: "B89968")
+        case .success: return Color(hex: "8FA880")
+        case .danger: return CadreColors.danger
+        }
+    }
+}
+
+/// Section container with uppercase label and glass card background.
+struct SettingsSectionView<Content: View>: View {
+    let title: String
+    @ViewBuilder let content: Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text(title)
+                // .caption (12pt default) is the smallest semantic style that
+                // passes the XCTest Dynamic Type audit. .caption2 (11pt default)
+                // would be visually closer but causes a false-positive "partially
+                // unsupported" failure due to a tool limitation with weight-modified
+                // .caption2 fonts. One point difference is imperceptible at 11-12pt.
+                .font(.caption.weight(.bold))
+                .tracking(0.6)
+                .foregroundStyle(CadreColors.textTertiary)
+                .textCase(.uppercase)
+                .padding(.horizontal, 22)
+                .padding(.top, 22)
+                .padding(.bottom, 8)
+
+            VStack(spacing: 0) {
+                content
+            }
+            // clipShape removed: glassCard provides the rounded visual container.
+            // Removing clipShape ensures row label accessibility frames don't
+            // touch the clip boundary — which the "text clipped" audit flags even
+            // for elements deep inside the card whose frames technically start at
+            // the card's y=0 edge.
+            .glassCard()
+            .padding(.horizontal, 16)
+        }
+    }
+}
+
+/// Thin divider matching `.divider` mockup token.
+struct SettingsDivider: View {
+    var body: some View {
+        Rectangle()
+            .fill(CadreColors.divider)
+            .frame(height: 0.5)
+            .padding(.leading, 50) // icon width (28) + gap (14) + inner padding (8)
+    }
+}
+
+/// Inline segmented toggle for lb/kg, in/cm.
+struct SegmentedToggle: View {
+    let options: [String]
+    @Binding var selection: String
+
+    var body: some View {
+        HStack(spacing: 1) {
+            ForEach(options, id: \.self) { option in
+                Text(option)
+                    // .caption (12pt default) matches original 12pt while enabling DT scaling.
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(selection == option ? .white : CadreColors.textSecondary)
+                    .padding(.vertical, 5)
+                    .padding(.horizontal, 12)
+                    .background(
+                        // Use accentButton (slightly darker than accent) so white
+                        // text achieves ≥4.5:1 WCAG AA contrast on the active pill.
+                        // Inactive text (textSecondary) is on Color.clear/cardElevated —
+                        // handled in AccessibilityAuditUITests exclusions.
+                        RoundedRectangle(cornerRadius: 6)
+                            .fill(selection == option ? CadreColors.accentButton : Color.clear)
+                    )
+                    .contentShape(Rectangle())
+                    .onTapGesture { selection = option }
+            }
+        }
+        .padding(2)
+        .background(CadreColors.cardElevated, in: RoundedRectangle(cornerRadius: 8))
+    }
+}

--- a/Baseline/Views/Settings/SettingsDeveloperSection.swift
+++ b/Baseline/Views/Settings/SettingsDeveloperSection.swift
@@ -1,0 +1,70 @@
+#if DEBUG
+import SwiftUI
+import SwiftData
+
+/// DEBUG-only Developer section — load realistic sample data or wipe
+/// everything for preview/testing. The whole file is `#if DEBUG`-gated so it
+/// doesn't reach release builds.
+struct SettingsDeveloperSection: View {
+    @Environment(\.modelContext) private var modelContext
+    @State private var showLoadConfirm = false
+    @State private var showClearConfirm = false
+
+    var body: some View {
+        SettingsSectionView(title: "DEVELOPER") {
+            Button {
+                showLoadConfirm = true
+            } label: {
+                SettingsRow(
+                    icon: "flask",
+                    label: "Load Test Data",
+                    value: nil,
+                    style: .action
+                )
+            }
+            SettingsDivider()
+            Button {
+                showClearConfirm = true
+            } label: {
+                SettingsRow(
+                    icon: "xmark.bin",
+                    label: "Clear All Data",
+                    value: nil,
+                    style: .danger
+                )
+            }
+
+            Text("Debug build only. Load realistic sample data to preview the app.")
+                .font(.caption)
+                .foregroundStyle(CadreColors.textTertiary)
+                .padding(.horizontal, 22)
+                .padding(.top, 8)
+                .padding(.bottom, 4)
+        }
+        .confirmationDialog(
+            "Load test data?",
+            isPresented: $showLoadConfirm,
+            titleVisibility: .visible
+        ) {
+            Button("Load Test Data") {
+                TestDataSeeder.seed(context: modelContext)
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This will replace all existing data with sample entries.")
+        }
+        .confirmationDialog(
+            "Clear all data?",
+            isPresented: $showClearConfirm,
+            titleVisibility: .visible
+        ) {
+            Button("Clear Everything", role: .destructive) {
+                TestDataSeeder.clearAll(context: modelContext)
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This will delete all weight entries, scans, and measurements.")
+        }
+    }
+}
+#endif

--- a/Baseline/Views/Settings/SettingsHealthSection.swift
+++ b/Baseline/Views/Settings/SettingsHealthSection.swift
@@ -1,0 +1,128 @@
+import SwiftUI
+import HealthKit
+import UIKit
+
+/// Apple Health section of the Settings screen. Shown only on devices where
+/// HealthKit is available. Owns its own auth-status state and queries it on
+/// appear; tapping the row prompts for permission (or deep-links to system
+/// Settings if the user previously denied).
+struct SettingsHealthSection: View {
+    @State private var healthKitStatus: HKAuthorizationStatus = .notDetermined
+
+    @ViewBuilder
+    var body: some View {
+        if HKHealthStore.isHealthDataAvailable() {
+            SettingsSectionView(title: "HEALTH") {
+                Button(action: handleHealthRowTap) {
+                    HStack(spacing: 14) {
+                        SettingsRowIcon(
+                            systemName: healthKitIcon,
+                            tint: healthKitIconTint
+                        )
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Apple Health")
+                                .font(.subheadline.weight(.medium))
+                                .foregroundStyle(CadreColors.textPrimary)
+                                .tracking(-0.1)
+                            Text(healthKitSubtitle)
+                                .font(.caption.weight(.medium))
+                                .foregroundStyle(CadreColors.textTertiary)
+                        }
+                        Spacer()
+                        Text(healthKitStatusLabel)
+                            // .caption (12pt) passes DT audit; .caption2 (11pt) with
+                            // weight modifier causes false-positive tool failure.
+                            .font(.caption.weight(.bold))
+                            .textCase(.uppercase)
+                            .tracking(0.4)
+                            .foregroundStyle(healthKitStatusColor)
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 3)
+                            .background(
+                                healthKitStatusColor.opacity(0.12),
+                                in: RoundedRectangle(cornerRadius: 5)
+                            )
+                        if healthKitStatus != .sharingAuthorized {
+                            Image(systemName: "chevron.right")
+                                .font(.system(size: 12, weight: .semibold))
+                                .foregroundStyle(CadreColors.textTertiary)
+                        }
+                    }
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 14)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .disabled(healthKitStatus == .sharingAuthorized)
+            }
+            .onAppear(perform: refreshHealthKitStatus)
+        }
+    }
+
+    /// Query the write-auth status for a representative type we actually save
+    /// (bodyMass). HealthKit deliberately won't tell you *read* status, but
+    /// write status is accurate and mirrors the user's consent.
+    private func refreshHealthKitStatus() {
+        guard HKHealthStore.isHealthDataAvailable() else {
+            healthKitStatus = .sharingDenied // treat as unavailable for the UI
+            return
+        }
+        healthKitStatus = HKHealthStore().authorizationStatus(for: HKQuantityType(.bodyMass))
+    }
+
+    private func handleHealthRowTap() {
+        switch healthKitStatus {
+        case .notDetermined:
+            Task {
+                await HealthKitManager.requestAuthorizationIfNeeded()
+                await MainActor.run { refreshHealthKitStatus() }
+            }
+        case .sharingDenied:
+            if let url = URL(string: UIApplication.openSettingsURLString) {
+                UIApplication.shared.open(url)
+            }
+        default:
+            break
+        }
+    }
+
+    private var healthKitIcon: String {
+        switch healthKitStatus {
+        case .sharingAuthorized: return "heart.fill"
+        case .sharingDenied: return "heart.slash"
+        default: return "heart"
+        }
+    }
+
+    private var healthKitIconTint: SettingsIconTint {
+        switch healthKitStatus {
+        case .sharingAuthorized: return .success
+        case .sharingDenied: return .danger
+        default: return .accent
+        }
+    }
+
+    private var healthKitStatusLabel: String {
+        switch healthKitStatus {
+        case .sharingAuthorized: return "Connected"
+        case .sharingDenied: return "Denied"
+        default: return "Not set"
+        }
+    }
+
+    private var healthKitStatusColor: Color {
+        switch healthKitStatus {
+        case .sharingAuthorized: return CadreColors.success
+        case .sharingDenied: return CadreColors.danger
+        default: return CadreColors.textSecondary
+        }
+    }
+
+    private var healthKitSubtitle: String {
+        switch healthKitStatus {
+        case .sharingAuthorized: return "Baseline is syncing to Apple Health."
+        case .sharingDenied: return "Tap to enable in Settings."
+        default: return "Tap to allow Baseline to write your metrics."
+        }
+    }
+}

--- a/Baseline/Views/Settings/SettingsView.swift
+++ b/Baseline/Views/Settings/SettingsView.swift
@@ -1,7 +1,5 @@
 import SwiftUI
 import SwiftData
-import HealthKit
-import UIKit
 
 /// Settings screen — 7 grouped sections matching `settings-v1-2026-04-05.html`.
 ///
@@ -12,11 +10,6 @@ struct SettingsView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var vm: SettingsViewModel
     @State private var showDeleteConfirmation = false
-    @State private var healthKitStatus: HKAuthorizationStatus = .notDetermined
-    #if DEBUG
-    @State private var showLoadConfirm = false
-    @State private var showClearConfirm = false
-    #endif
 
     init(viewModel: SettingsViewModel? = nil) {
         self._vm = State(initialValue: viewModel ?? SettingsViewModel())
@@ -32,11 +25,11 @@ struct SettingsView: View {
                     unitsSection
                     appearanceSection
                     dataSection
-                    healthSection
+                    SettingsHealthSection()
                     aboutSection
                     resetSection
                     #if DEBUG
-                    developerSection
+                    SettingsDeveloperSection()
                     #endif
                 }
                 .padding(.bottom, CadreSpacing.xl)
@@ -64,62 +57,6 @@ struct SettingsView: View {
             Button("Cancel", role: .cancel) {}
         } message: {
             Text("This is permanent. Your data cannot be recovered.")
-        }
-        #if DEBUG
-        .confirmationDialog(
-            "Load test data?",
-            isPresented: $showLoadConfirm,
-            titleVisibility: .visible
-        ) {
-            Button("Load Test Data") {
-                TestDataSeeder.seed(context: modelContext)
-            }
-            Button("Cancel", role: .cancel) {}
-        } message: {
-            Text("This will replace all existing data with sample entries.")
-        }
-        .confirmationDialog(
-            "Clear all data?",
-            isPresented: $showClearConfirm,
-            titleVisibility: .visible
-        ) {
-            Button("Clear Everything", role: .destructive) {
-                TestDataSeeder.clearAll(context: modelContext)
-            }
-            Button("Cancel", role: .cancel) {}
-        } message: {
-            Text("This will delete all weight entries, scans, and measurements.")
-        }
-        #endif
-        .onAppear(perform: refreshHealthKitStatus)
-    }
-
-    // MARK: - HealthKit Status
-
-    /// Query the write-auth status for a representative type we actually save
-    /// (bodyMass). HealthKit deliberately won't tell you *read* status, but
-    /// write status is accurate and mirrors the user's consent.
-    private func refreshHealthKitStatus() {
-        guard HKHealthStore.isHealthDataAvailable() else {
-            healthKitStatus = .sharingDenied // treat as unavailable for the UI
-            return
-        }
-        healthKitStatus = HKHealthStore().authorizationStatus(for: HKQuantityType(.bodyMass))
-    }
-
-    private func handleHealthRowTap() {
-        switch healthKitStatus {
-        case .notDetermined:
-            Task {
-                await HealthKitManager.requestAuthorizationIfNeeded()
-                await MainActor.run { refreshHealthKitStatus() }
-            }
-        case .sharingDenied:
-            if let url = URL(string: UIApplication.openSettingsURLString) {
-                UIApplication.shared.open(url)
-            }
-        default:
-            break
         }
     }
 
@@ -274,97 +211,6 @@ struct SettingsView: View {
         }
     }
 
-    // MARK: - Health Section
-
-    @ViewBuilder
-    private var healthSection: some View {
-        if HKHealthStore.isHealthDataAvailable() {
-            SettingsSectionView(title: "HEALTH") {
-                Button(action: handleHealthRowTap) {
-                    HStack(spacing: 14) {
-                        SettingsRowIcon(
-                            systemName: healthKitIcon,
-                            tint: healthKitIconTint
-                        )
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text("Apple Health")
-                                .font(.subheadline.weight(.medium))
-                                .foregroundStyle(CadreColors.textPrimary)
-                                .tracking(-0.1)
-                            Text(healthKitSubtitle)
-                                .font(.caption.weight(.medium))
-                                .foregroundStyle(CadreColors.textTertiary)
-                        }
-                        Spacer()
-                        Text(healthKitStatusLabel)
-                            // .caption (12pt) passes DT audit; .caption2 (11pt) with
-                            // weight modifier causes false-positive tool failure.
-                            .font(.caption.weight(.bold))
-                            .textCase(.uppercase)
-                            .tracking(0.4)
-                            .foregroundStyle(healthKitStatusColor)
-                            .padding(.horizontal, 8)
-                            .padding(.vertical, 3)
-                            .background(
-                                healthKitStatusColor.opacity(0.12),
-                                in: RoundedRectangle(cornerRadius: 5)
-                            )
-                        if healthKitStatus != .sharingAuthorized {
-                            Image(systemName: "chevron.right")
-                                .font(.system(size: 12, weight: .semibold))
-                                .foregroundStyle(CadreColors.textTertiary)
-                        }
-                    }
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 14)
-                    .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-                .disabled(healthKitStatus == .sharingAuthorized)
-            }
-        }
-    }
-
-    private var healthKitIcon: String {
-        switch healthKitStatus {
-        case .sharingAuthorized: return "heart.fill"
-        case .sharingDenied: return "heart.slash"
-        default: return "heart"
-        }
-    }
-
-    private var healthKitIconTint: SettingsIconTint {
-        switch healthKitStatus {
-        case .sharingAuthorized: return .success
-        case .sharingDenied: return .danger
-        default: return .accent
-        }
-    }
-
-    private var healthKitStatusLabel: String {
-        switch healthKitStatus {
-        case .sharingAuthorized: return "Connected"
-        case .sharingDenied: return "Denied"
-        default: return "Not set"
-        }
-    }
-
-    private var healthKitStatusColor: Color {
-        switch healthKitStatus {
-        case .sharingAuthorized: return CadreColors.success
-        case .sharingDenied: return CadreColors.danger
-        default: return CadreColors.textSecondary
-        }
-    }
-
-    private var healthKitSubtitle: String {
-        switch healthKitStatus {
-        case .sharingAuthorized: return "Baseline is syncing to Apple Health."
-        case .sharingDenied: return "Tap to enable in Settings."
-        default: return "Tap to allow Baseline to write your metrics."
-        }
-    }
-
     // MARK: - About Section
 
     private var aboutSection: some View {
@@ -413,258 +259,6 @@ struct SettingsView: View {
                 )
             }
         }
-    }
-
-    // MARK: - Developer Section (DEBUG only)
-
-    #if DEBUG
-    private var developerSection: some View {
-        SettingsSectionView(title: "DEVELOPER") {
-            Button {
-                showLoadConfirm = true
-            } label: {
-                SettingsRow(
-                    icon: "flask",
-                    label: "Load Test Data",
-                    value: nil,
-                    style: .action
-                )
-            }
-            SettingsDivider()
-            Button {
-                showClearConfirm = true
-            } label: {
-                SettingsRow(
-                    icon: "xmark.bin",
-                    label: "Clear All Data",
-                    value: nil,
-                    style: .danger
-                )
-            }
-
-            Text("Debug build only. Load realistic sample data to preview the app.")
-                .font(.caption)
-                .foregroundStyle(CadreColors.textTertiary)
-                .padding(.horizontal, 22)
-                .padding(.top, 8)
-                .padding(.bottom, 4)
-        }
-    }
-    #endif
-}
-
-// MARK: - Supporting Components
-
-/// Row display style determines trailing accessory.
-enum SettingsRowStyle {
-    case push
-    /// Push row that is an action (no "Not set" fallback when value is nil).
-    case action
-    case info
-    case externalLink
-    case danger
-    case badge(String)
-}
-
-/// Tint override for row icons.
-enum SettingsIconTint {
-    case accent
-    case secondary
-    case success
-    case danger
-}
-
-/// Reusable settings row — icon + label + optional value + trailing accessory.
-struct SettingsRow: View {
-    let icon: String
-    let label: String
-    let value: String?
-    let style: SettingsRowStyle
-    var iconTint: SettingsIconTint = .accent
-
-    var body: some View {
-        HStack(spacing: 14) {
-            SettingsRowIcon(systemName: icon, tint: iconTint)
-
-            // .subheadline (15pt default) matches the original 14pt design intent
-            // while enabling Dynamic Type scaling for accessibility compliance.
-            Text(label)
-                .font(.subheadline.weight(.medium))
-                .foregroundStyle(style.labelColor)
-                .tracking(-0.1)
-
-            Spacer()
-
-            // Value or trailing accessory
-            switch style {
-            case .push:
-                if let value {
-                    // .footnote (13pt default) matches the original 13pt value text.
-                    Text(value)
-                        .font(.footnote.weight(.medium))
-                        .foregroundStyle(CadreColors.textSecondary)
-                } else {
-                    Text("Not set")
-                        .font(.footnote.weight(.medium))
-                        .foregroundStyle(CadreColors.textTertiary)
-                }
-                Image(systemName: "chevron.right")
-                    .font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(CadreColors.textTertiary)
-
-            case .action:
-                if let value {
-                    Text(value)
-                        .font(.footnote.weight(.medium))
-                        .foregroundStyle(CadreColors.textSecondary)
-                }
-                Image(systemName: "chevron.right")
-                    .font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(CadreColors.textTertiary)
-
-            case .info:
-                if let value {
-                    Text(value)
-                        .font(.footnote.weight(.medium))
-                        .foregroundStyle(CadreColors.textSecondary)
-                }
-
-            case .externalLink:
-                Image(systemName: "arrow.up.right")
-                    .font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(CadreColors.textTertiary)
-
-            case .danger:
-                Image(systemName: "chevron.right")
-                    .font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(CadreColors.danger.opacity(0.6))
-
-            case .badge(let text):
-                Text(text)
-                    // .caption (12pt) passes DT audit; .caption2 (11pt) with weight
-                    // modifier causes a tool false-positive ("partially unsupported").
-                    .font(.caption.weight(.bold))
-                    .textCase(.uppercase)
-                    .tracking(0.4)
-                    .foregroundStyle(CadreColors.textTertiary)
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 3)
-                    .background(CadreColors.cardElevated, in: RoundedRectangle(cornerRadius: 5))
-            }
-        }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 14)
-        .contentShape(Rectangle())
-    }
-}
-
-private extension SettingsRowStyle {
-    var labelColor: Color {
-        switch self {
-        case .danger: return CadreColors.danger
-        default: return CadreColors.textPrimary
-        }
-    }
-}
-
-/// 28pt rounded-rect icon container matching the mockup `.row .row-icon`.
-struct SettingsRowIcon: View {
-    let systemName: String
-    var tint: SettingsIconTint = .accent
-
-    var body: some View {
-        Image(systemName: systemName)
-            .font(.system(size: 15, weight: .medium))
-            .foregroundStyle(tint.color)
-            .frame(width: 28, height: 28)
-            .background(CadreColors.cardElevated, in: RoundedRectangle(cornerRadius: 8))
-    }
-}
-
-private extension SettingsIconTint {
-    var color: Color {
-        switch self {
-        case .accent: return CadreColors.accent
-        case .secondary: return Color(hex: "B89968")
-        case .success: return Color(hex: "8FA880")
-        case .danger: return CadreColors.danger
-        }
-    }
-}
-
-/// Section container with uppercase label and glass card background.
-struct SettingsSectionView<Content: View>: View {
-    let title: String
-    @ViewBuilder let content: Content
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            Text(title)
-                // .caption (12pt default) is the smallest semantic style that
-                // passes the XCTest Dynamic Type audit. .caption2 (11pt default)
-                // would be visually closer but causes a false-positive "partially
-                // unsupported" failure due to a tool limitation with weight-modified
-                // .caption2 fonts. One point difference is imperceptible at 11-12pt.
-                .font(.caption.weight(.bold))
-                .tracking(0.6)
-                .foregroundStyle(CadreColors.textTertiary)
-                .textCase(.uppercase)
-                .padding(.horizontal, 22)
-                .padding(.top, 22)
-                .padding(.bottom, 8)
-
-            VStack(spacing: 0) {
-                content
-            }
-            // clipShape removed: glassCard provides the rounded visual container.
-            // Removing clipShape ensures row label accessibility frames don't
-            // touch the clip boundary — which the "text clipped" audit flags even
-            // for elements deep inside the card whose frames technically start at
-            // the card's y=0 edge.
-            .glassCard()
-            .padding(.horizontal, 16)
-        }
-    }
-}
-
-/// Thin divider matching `.divider` mockup token.
-struct SettingsDivider: View {
-    var body: some View {
-        Rectangle()
-            .fill(CadreColors.divider)
-            .frame(height: 0.5)
-            .padding(.leading, 50) // icon width (28) + gap (14) + inner padding (8)
-    }
-}
-
-/// Inline segmented toggle for lb/kg, in/cm.
-struct SegmentedToggle: View {
-    let options: [String]
-    @Binding var selection: String
-
-    var body: some View {
-        HStack(spacing: 1) {
-            ForEach(options, id: \.self) { option in
-                Text(option)
-                    // .caption (12pt default) matches original 12pt while enabling DT scaling.
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(selection == option ? .white : CadreColors.textSecondary)
-                    .padding(.vertical, 5)
-                    .padding(.horizontal, 12)
-                    .background(
-                        // Use accentButton (slightly darker than accent) so white
-                        // text achieves ≥4.5:1 WCAG AA contrast on the active pill.
-                        // Inactive text (textSecondary) is on Color.clear/cardElevated —
-                        // handled in AccessibilityAuditUITests exclusions.
-                        RoundedRectangle(cornerRadius: 6)
-                            .fill(selection == option ? CadreColors.accentButton : Color.clear)
-                    )
-                    .contentShape(Rectangle())
-                    .onTapGesture { selection = option }
-            }
-        }
-        .padding(2)
-        .background(CadreColors.cardElevated, in: RoundedRectangle(cornerRadius: 8))
     }
 }
 


### PR DESCRIPTION
SettingsView was 676 lines packing four distinct concerns: the screen itself, HealthKit integration, a DEBUG-only Developer section, and a reusable Settings UI kit. Decomposing along the real seams.

## What moved
Each extraction has its own state, dependencies, and single responsibility:

| New file | What | Why it's a real seam |
|---|---|---|
| **`SettingsComponents.swift`** (216 lines) | The seven reusable types: `SettingsRowStyle`, `SettingsIconTint`, `SettingsRow`, `SettingsRowIcon`, `SettingsSectionView`, `SettingsDivider`, `SegmentedToggle` | They're a UI kit, not a screen. Now usable from anywhere, not buried |
| **`SettingsHealthSection.swift`** (128 lines) | Apple Health section. Owns its own `healthKitStatus` `@State`, queries on appear, encapsulates the tap handler and the five status-display helpers. Hidden on devices without HealthKit | Real per-section state + external dependency (HealthKit) + self-contained behavior |
| **`SettingsDeveloperSection.swift`** (70 lines) | DEBUG-only Load/Clear test data tools. Whole file `#if DEBUG`-gated. Owns its `showLoadConfirm`/`showClearConfirm` `@State` and its two `confirmationDialog` modifiers | DEBUG-gated, owns local state, owns its own modal flow |

## What stayed inline
The smaller body sections (profile, units, appearance, data, about, reset) stay in `SettingsView` — each is 13–50 lines of pure composition over the shared components, no per-section state. Extracting them would just add parameter threading without making any concern simpler (the ScanReviewForm-pt3 trap).

`SettingsView.swift`: **676 → 270 lines** (out of the oversized list).

## Behavior
Verbatim move — no behavior change. Health onAppear refresh runs when the health section itself appears (same effective timing). DEBUG dialogs travel with the developer section.

## Verification
- `make lint` 0 (`--strict`)
- `make build` succeeds
- `make test` — 272 logic + 13 UI green, including `testSettingsScreenAccessibility`

Part of #80.

🤖 Generated with [Claude Code](https://claude.com/claude-code)